### PR TITLE
Bugfix: When the player resets (via F12 or Menu) switches and variables ...

### DIFF
--- a/src/rpg_setup.cpp
+++ b/src/rpg_setup.cpp
@@ -93,8 +93,10 @@ void RPG::SaveSystem::Setup() {
 	frame_count = 0;
 	graphics_name = system.system_name;
 	switches_size = Data::switches.size();
+	switches.clear();
 	switches.resize(switches_size);
 	variables_size = Data::variables.size();
+	variables.clear();
 	variables.resize(variables_size);
 	message_transparent = -1;
 	message_position = -1;


### PR DESCRIPTION
...are not reset to the default values.

Because the vectors already have the proper size resize will not clear them.

Note that this only fixes the problem on the libreaders side. The Player has another bug related to this... (will fix it later)
