### PR TITLE
Add `subdir-objects` to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.68])
 AC_INIT([easyrpg-readers],[0.1],[https://github.com/EasyRPG/Readers/issues])
 
 AC_CONFIG_AUX_DIR([builds/autoconf])
-AM_INIT_AUTOMAKE([1.11 foreign -Wall -Werror -Wno-extra-portability])
+AM_INIT_AUTOMAKE([1.11 foreign subdir-objects  -Wall -Werror -Wno-extra-portability])
 AM_MAINTAINER_MODE([enable])
 AM_SILENT_RULES([yes])
 


### PR DESCRIPTION
Else throwing several errors as follows:

src/Makefile.am:2: warning: source file 'generated/ldb_actor.cpp' is in a subdirectory,
src/Makefile.am:2: but option 'subdir-objects' is disabled

automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
