### PR TITLE
Fix encoding detection when RPG_RT.ini is not in working directory.

### DIFF
--- a/include/ldb_reader.h
+++ b/include/ldb_reader.h
@@ -49,8 +49,8 @@
  * LDB Reader namespace.
  */
 namespace LDB_Reader {
-	bool Load(const std::string &filename);
-	bool Save(const std::string &filename);
+	bool Load(const std::string &filename, const std::string &encoding);
+	bool Save(const std::string &filename, const std::string &encoding);
 	bool SaveXml(const std::string &filename);
 	bool LoadXml(const std::string &filename);
 }

--- a/include/lmt_reader.h
+++ b/include/lmt_reader.h
@@ -29,8 +29,8 @@
  * LMT Reader namespace.
  */
 namespace LMT_Reader {
-	bool Load(const std::string &filename);
-	bool Save(const std::string& filename);
+	bool Load(const std::string &filename, const std::string &encoding);
+	bool Save(const std::string& filename, const std::string &encoding);
 	bool SaveXml(const std::string& filename);
 	bool LoadXml(const std::string &filename);
 }

--- a/include/lmu_reader.h
+++ b/include/lmu_reader.h
@@ -27,8 +27,8 @@
  * LMU Reader namespace.
  */
 namespace LMU_Reader {
-	std::auto_ptr<RPG::Map> Load(const std::string &filename);
-	bool Save(const std::string& filename, const RPG::Map& map);
+	std::auto_ptr<RPG::Map> Load(const std::string &filename, const std::string &encoding);
+	bool Save(const std::string& filename, const RPG::Map& map, const std::string &encoding);
 	bool SaveXml(const std::string& filename, const RPG::Map& map);
 	std::auto_ptr<RPG::Map> LoadXml(const std::string &filename);
 }

--- a/include/lsd_reader.h
+++ b/include/lsd_reader.h
@@ -33,8 +33,8 @@ namespace LSD_Reader {
 	std::time_t ToUnixTime(double const ms);
 	double GenerateTimeStamp(std::time_t const t = std::time(NULL));
 
-	std::auto_ptr<RPG::Save> Load(const std::string &filename);
-	bool Save(const std::string& filename, const RPG::Save& save);
+	std::auto_ptr<RPG::Save> Load(const std::string &filename, const std::string &encoding);
+	bool Save(const std::string& filename, const RPG::Save& save, const std::string &encoding);
 	bool SaveXml(const std::string& filename, const RPG::Save& save);
 	std::auto_ptr<RPG::Save> LoadXml(const std::string &filename);
 }

--- a/include/reader_util.h
+++ b/include/reader_util.h
@@ -35,20 +35,23 @@ namespace ReaderUtil {
 	
 	/**
 	 * Returns the encoding set in the ini file.
+	 * 
+	 * @param ini_file The ini file to parse.
 	 *
 	 * @return Windows: codepage, other: iconv name,
 	 *         empty string if not found.
 	 */
-	std::string GetEncoding();
+	std::string GetEncoding(const std::string& ini_file);
 
 	/**
 	 * Converts a string to unicode.
-	 * src encoding is read from the ini file.
 	 *
 	 * @param str_to_encode string to encode
+	 * @param source_encoding Encoding of str_to_encode
+	 *
 	 * @return the recoded string.
 	 */
-	std::string Recode(const std::string& str_to_encode);
+	std::string Recode(const std::string& str_to_encode, const std::string& source_encoding);
 
 	/**
 	 * Converts a string between encodings.

--- a/src/ldb_reader.cpp
+++ b/src/ldb_reader.cpp
@@ -25,8 +25,8 @@
 /**
  * Loads Database.
  */
-bool LDB_Reader::Load(const std::string& filename) {
-	LcfReader reader(filename, ReaderUtil::GetEncoding());
+bool LDB_Reader::Load(const std::string& filename, const std::string &encoding) {
+	LcfReader reader(filename, encoding);
 	if (!reader.IsOk()) {
 		LcfReader::SetError("Couldn't find %s database file.\n", filename.c_str());
 		return false;
@@ -47,8 +47,8 @@ bool LDB_Reader::Load(const std::string& filename) {
 /**
  * Saves Database.
  */
-bool LDB_Reader::Save(const std::string& filename) {
-	LcfWriter writer(filename, ReaderUtil::GetEncoding());
+bool LDB_Reader::Save(const std::string& filename, const std::string &encoding) {
+	LcfWriter writer(filename, encoding);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't open %s database file.\n", filename.c_str());
 		return false;

--- a/src/lmt_reader.cpp
+++ b/src/lmt_reader.cpp
@@ -25,8 +25,8 @@
 /**
  * Loads Map Tree.
  */
-bool LMT_Reader::Load(const std::string& filename) {
-	LcfReader reader(filename, ReaderUtil::GetEncoding());
+bool LMT_Reader::Load(const std::string& filename, const std::string &encoding) {
+	LcfReader reader(filename, encoding);
 	if (!reader.IsOk()) {
 		LcfReader::SetError("Couldn't find %s map tree file.\n", filename.c_str());
 		return false;
@@ -47,8 +47,8 @@ bool LMT_Reader::Load(const std::string& filename) {
 /**
  * Saves Map Tree.
  */
-bool LMT_Reader::Save(const std::string& filename) {
-	LcfWriter writer(filename, ReaderUtil::GetEncoding());
+bool LMT_Reader::Save(const std::string& filename, const std::string &encoding) {
+	LcfWriter writer(filename, encoding);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't find %s map tree file.\n", filename.c_str());
 		return false;

--- a/src/lmu_reader.cpp
+++ b/src/lmu_reader.cpp
@@ -25,8 +25,8 @@
 /**
  * Loads Map.
  */
-std::auto_ptr<RPG::Map> LMU_Reader::Load(const std::string& filename) {
-	LcfReader reader(filename, ReaderUtil::GetEncoding());
+std::auto_ptr<RPG::Map> LMU_Reader::Load(const std::string& filename, const std::string &encoding) {
+	LcfReader reader(filename, encoding);
 	if (!reader.IsOk()) {
 		LcfReader::SetError("Couldn't find %s map file.\n", filename.c_str());
 		return std::auto_ptr<RPG::Map>(NULL);
@@ -49,8 +49,8 @@ std::auto_ptr<RPG::Map> LMU_Reader::Load(const std::string& filename) {
 /**
  * Saves Map.
  */
-bool LMU_Reader::Save(const std::string& filename, const RPG::Map& map) {
-	LcfWriter writer(filename, ReaderUtil::GetEncoding());
+bool LMU_Reader::Save(const std::string& filename, const RPG::Map& map, const std::string &encoding) {
+	LcfWriter writer(filename, encoding);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't find %s map file.\n", filename.c_str());
 		return false;

--- a/src/lsd_reader.cpp
+++ b/src/lsd_reader.cpp
@@ -46,8 +46,8 @@ double LSD_Reader::GenerateTimeStamp(std::time_t const t) {
 /**
  * Loads Savegame.
  */
-std::auto_ptr<RPG::Save> LSD_Reader::Load(const std::string& filename) {
-	LcfReader reader(filename, ReaderUtil::GetEncoding());
+std::auto_ptr<RPG::Save> LSD_Reader::Load(const std::string& filename, const std::string &encoding) {
+	LcfReader reader(filename, encoding);
 	if (!reader.IsOk()) {
 		LcfReader::SetError("Couldn't find %s save file.\n", filename.c_str());
 		return std::auto_ptr<RPG::Save>(NULL);
@@ -69,8 +69,8 @@ std::auto_ptr<RPG::Save> LSD_Reader::Load(const std::string& filename) {
 /**
  * Saves Savegame.
  */
-bool LSD_Reader::Save(const std::string& filename, const RPG::Save& save) {
-	LcfWriter writer(filename, ReaderUtil::GetEncoding());
+bool LSD_Reader::Save(const std::string& filename, const RPG::Save& save, const std::string &encoding) {
+	LcfWriter writer(filename, encoding);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't find %s save file.\n", filename.c_str());
 		return false;

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -46,13 +46,13 @@ std::string ReaderUtil::CodepageToIconv(int codepage) {
 	return out.str();
 }
 
-std::string ReaderUtil::GetEncoding() {
-	INIReader ini("RPG_RT.ini");
+std::string ReaderUtil::GetEncoding(const std::string& ini_file) {
+	INIReader ini(ini_file);
 	if (ini.ParseError() != -1) {
-#if defined(GEKKO) || defined(PSP)
-		std::string default_enc = "1252";
-#else
+#ifdef _WIN32
 		std::string default_enc = "";
+#else
+		std::string default_enc = "1252";
 #endif
 		std::string encoding = ini.Get("EasyRpg", "Encoding", default_enc);
 
@@ -76,11 +76,11 @@ std::string ReaderUtil::GetEncoding() {
 	return "";
 }
 
-std::string ReaderUtil::Recode(const std::string& str_to_encode) {
+std::string ReaderUtil::Recode(const std::string& str_to_encode, const std::string& source_encoding) {
 #ifdef _WIN32
-	return ReaderUtil::Recode(str_to_encode, GetEncoding(), "65001");
+	return ReaderUtil::Recode(str_to_encode, source_encoding, "65001");
 #else
-	return ReaderUtil::Recode(str_to_encode, GetEncoding(), "UTF-8");
+	return ReaderUtil::Recode(str_to_encode, source_encoding, "UTF-8");
 #endif
 }
 


### PR DESCRIPTION
Encoding must be passed by Player (or LCF2XML that one needs an update) now.

I wrote this for the Android port but I hope this helps the Wii (issue #115), too.
