### PR TITLE
allow cross-compiling liblcf with autotools for big endian systems like wii

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,12 @@ AS_IF([test "x$enable_xml" != "xno"],[
 	PKG_CHECK_MODULES([EXPAT],[expat],[AC_DEFINE([LCF_SUPPORT_XML],[1],[Enable XML reading support (expat)])])
 ])
 
+# Check for endianess
+AC_C_BIGENDIAN
+if [ test "$ac_cv_c_bigendian" = "yes" ]; then
+	AC_DEFINE(LCF_BIG_ENDIAN,1,[Define if byte order is big-endian])
+fi
+
 # Checks for header files.
 AC_CHECK_HEADERS([stdint.h],[],[AC_MSG_ERROR([cannot find stdint.h, bailing out])])
 

--- a/src/reader_options.h
+++ b/src/reader_options.h
@@ -36,15 +36,15 @@
 #endif
 
 /**
- * Enables support for XML file reading and writing.
+ * Enables support for XML file reading and writing (deprecated).
  * This option adds libexpat as a dependency.
  */
 //#ifndef LCF_SUPPORT_XML
 //#  define LCF_SUPPORT_XML
 //#endif
 
-/** Enables big endian byte order for Wii port. */
-#ifdef GEKKO
+/** Enables big endian byte order for Wii port (deprecated). */
+#if defined(GEKKO) && !defined(LCF_BIG_ENDIAN)
 #  define LCF_BIG_ENDIAN
 #endif
 


### PR DESCRIPTION
This allows to do

```
./configure --host=powerpc-eabi --prefix="$DEVKITPRO/portlibs/ppc" CXXFLAGS="-O2 -mcpu=750 -meabi -mhard-float"
make
make install
```

and use liblcf as all other portlibs for wii development.

Before this is ready, however, liblcf headers should be installed in subfolder (cleaner).
The old method of compiling (extracting/cloning in lib folder) is still supported, a safeguard against redefining `LCF_BIG_ENDIAN` is included.

A downside of the `AC_C_BIGENDIAN` macro is, that it is not guranteed to function when cross-compiling and when building universal binaries for mac os (ppc/intel).
