### PR TITLE
Fix autotools warning when using '--disable-icu'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,9 +19,9 @@ AC_PROG_CXX
 LT_INIT([win32-dll])
 
 # Checks for libraries.
-AC_ARG_ENABLE([xml],[AS_HELP_STRING([--disable-icu],[Disable ICU (fallback to iconv)])])
+AC_ARG_ENABLE([icu],[AS_HELP_STRING([--disable-icu],[Disable ICU encoding detection (fallback to iconv)])])
 AS_IF([test "x$enable_icu" != "xno"],[
-	AX_PKG_CHECK_MODULES([ICU],[icu-i18n],[],[AC_DEFINE([LCF_SUPPORT_ICU],[1],[Enable ICU support])])
+	AX_PKG_CHECK_MODULES([ICU],[icu-i18n],[],[AC_DEFINE([LCF_SUPPORT_ICU],[1],[Enable encoding detection (ICU)])])
 ])
 
 AC_ARG_ENABLE([xml],[AS_HELP_STRING([--disable-xml],[Disable XML reading support (expat)])])


### PR DESCRIPTION
Reword the help message a bit, to explicitly tell what it is used for