### PR TITLE
OS X: Skip system locale detection

### DIFF
--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -183,6 +183,9 @@ std::string ReaderUtil::GetEncoding(const std::string& ini_file) {
 std::string ReaderUtil::GetLocaleEncoding() {
 #ifdef _WIN32
 	int codepage = GetACP();
+#elif defined(__APPLE__) && defined(__MACH__)
+	// libstdc++ does not support locale properly at least on OS X
+	int codepage = 0;
 #else
 	int codepage = 1252;
 


### PR DESCRIPTION
This function is used to use the encoding based on system locale when automatic detection fails and there is no manual encoding set. However, libstdc++ locale support is not complete on OS X and will emit a runtime error when trying to call locale functions. The alternate libc++ runtime supports it properly, but it is supported since Mac OS X 10.7. Because Player currently runs on 10.5 and links with libstdc++, the locale code is disabled to prevent the runtime error.