### PR TITLE
ICU: print encoding conversion error codes to stderr

### DIFF
--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include <cstdlib>
+#include <cstdio>
 #include <sstream>
 #include <vector>
 
@@ -174,6 +175,8 @@ std::string ReaderUtil::GetEncoding(const std::string& ini_file) {
 	if (ini.ParseError() != -1) {
 		std::string encoding = ini.Get("EasyRPG", "Encoding", std::string());
 		if (!encoding.empty()) {
+			fprintf(stderr, "Encoding returned by INI parser: %s\n", encoding.c_str());
+			fprintf(stderr, "Encoding returned by CodepageToEncoding: : %s\n", ReaderUtil::CodepageToEncoding(atoi(encoding.c_str())).c_str());
 			return ReaderUtil::CodepageToEncoding(atoi(encoding.c_str()));
 		}
 	}

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -267,7 +267,7 @@ std::string ReaderUtil::Recode(const std::string& str_to_encode,
 	conv = ucnv_open(src_enc_str.c_str(), &status);
 	
 	if (status != U_ZERO_ERROR && status != U_AMBIGUOUS_ALIAS_WARNING) {
-		fprintf(stderr, "liblcf: ucnv_open(\"%s\") source encoding error: %d\n", src_enc_str.c_str(), status);
+		fprintf(stderr, "liblcf:  ucnv_open() error for source encoding \"%s\": %s\n", src_enc_str.c_str(), u_errorName(status));
 		return std::string();
 	}
 	status = U_ZERO_ERROR;
@@ -275,7 +275,7 @@ std::string ReaderUtil::Recode(const std::string& str_to_encode,
 	length = ucnv_toUChars(conv, unicode_str, size, str_to_encode.c_str(), -1, &status);
 	ucnv_close(conv);
 	if (status != U_ZERO_ERROR) {
-		fprintf(stderr, "liblcf: ucnv_toUChars() error: %d\n", status);
+		fprintf(stderr, "liblcf: ucnv_toUChars() error when encoding \"%s\": %s\n", str_to_encode.c_str(), u_errorName(status));
 		return std::string();
 	}
 
@@ -283,7 +283,7 @@ std::string ReaderUtil::Recode(const std::string& str_to_encode,
 
 	conv = ucnv_open(dst_enc_str.c_str(), &status);
 	if (status != U_ZERO_ERROR && status != U_AMBIGUOUS_ALIAS_WARNING) {
-		fprintf(stderr, "liblcf: ucnv_open(\"%s\") destination encoding error: %d\n", dst_enc_str.c_str(), status);
+		fprintf(stderr, "liblcf: ucnv_open() error for destination encoding \"%s\": %s\n", dst_enc_str.c_str(), u_errorName(status));
 		return std::string();
 	}
 	status = U_ZERO_ERROR;
@@ -291,7 +291,7 @@ std::string ReaderUtil::Recode(const std::string& str_to_encode,
 	ucnv_fromUChars(conv, result, length * 4, unicode_str, -1, &status);
 	ucnv_close(conv);
 	if (status != U_ZERO_ERROR) {
-		fprintf(stderr, "liblcf: ucnv_fromUChars() error: %d\n", status);
+		fprintf(stderr, "liblcf: ucnv_fromUChars() error: %s\n", u_errorName(status));
 		return std::string();
 	}
 


### PR DESCRIPTION
Until now, when a conversion was failing only returns an empty string as a result.
With this change, when a conversion failure occurs it will print the reason in the stderr.