### PR TITLE
Force MapInfo.type to appear and remove unnecessary Fixups

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -598,7 +598,7 @@ Encounter,troop_id,f,Ref<Troop>,0x01,0,Integer
 MapInfo,name,f,String,0x01,'',String. Note: Map ID 0 used to be game title but it should be ignored (TreeCtrl dummy editor dumped data); always use RPG_RT.ini GameTitle instead
 MapInfo,parent_map,f,Ref<Map>,0x02,0,Integer. Used to inherit parent map properties
 MapInfo,indentation,f,Integer,0x03,0,Integer. Dummy editor dumped data. Branch indentation level in TreeCtrl
-MapInfo,type,f,Integer,0x04,1,Integer. 0=lmt root (can be ignored); 1=map; 2=area
+MapInfo,type,f,Integer,0x04,-1,Integer. 0=lmt root (can be ignored); 1=map; 2=area
 MapInfo,scrollbar_x,f,Integer,0x05,0,Integer. Editor only
 MapInfo,scrollbar_y,f,Integer,0x06,0,Integer. Editor only
 MapInfo,expanded_node,f,Boolean,0x07,False,Flag. Editor only

--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -762,10 +762,10 @@ SaveScreen,tint_finish_red,f,Integer,0x01,100,int
 SaveScreen,tint_finish_green,f,Integer,0x02,100,int
 SaveScreen,tint_finish_blue,f,Integer,0x03,100,int
 SaveScreen,tint_finish_sat,f,Integer,0x04,100,int
-SaveScreen,tint_current_red,f,Double,0x0B,-1.0,double
-SaveScreen,tint_current_green,f,Double,0x0C,-1.0,double
-SaveScreen,tint_current_blue,f,Double,0x0D,-1.0,double
-SaveScreen,tint_current_sat,f,Double,0x0E,-1.0,double
+SaveScreen,tint_current_red,f,Double,0x0B,100.0,double
+SaveScreen,tint_current_green,f,Double,0x0C,100.0,double
+SaveScreen,tint_current_blue,f,Double,0x0D,100.0,double
+SaveScreen,tint_current_sat,f,Double,0x0E,100.0,double
 SaveScreen,tint_time_left,f,Integer,0x0F,0,int
 SaveScreen,flash_continuous,f,Boolean,0x14,False,int
 SaveScreen,flash_red,f,Integer,0x15,0,int
@@ -831,7 +831,7 @@ SavePartyLocation,layer,f,Integer,0x21,1,?
 SavePartyLocation,overlap_forbidden,f,Boolean,0x22,False,Flag
 SavePartyLocation,animation_type,f,Enum<EventPage_AnimType>,0x23,1,Integer
 SavePartyLocation,lock_facing,f,Boolean,0x24,False,facing locked
-SavePartyLocation,move_speed,f,Integer,0x25,-1,
+SavePartyLocation,move_speed,f,Integer,0x25,4,
 SavePartyLocation,move_route,f,MoveRoute,0x29,,chunks: RPG::MoveRoute
 SavePartyLocation,move_route_overwrite,f,Boolean,0x2A,False,Use custom move route
 SavePartyLocation,move_route_index,f,Integer,0x2B,0,Index of MoveEvent command route

--- a/generator/csv/setup.csv
+++ b/generator/csv/setup.csv
@@ -12,8 +12,6 @@ SaveMapInfo,void Setup(),
 SaveMapInfo,void Setup(const RPG::Map& map),"rpg_map.h"
 SaveMapInfo,void Setup(const RPG::MapInfo& map_info),"rpg_mapinfo.h"
 SaveMapInfo,void Fixup(const RPG::Map& map),
-SavePartyLocation,void Fixup(),
 SaveSystem,void Setup(),
 SaveSystem,void Fixup(),
-SaveScreen,void Fixup(),
 Parameters,void Setup(int final_level),

--- a/src/generated/rpg_mapinfo.cpp
+++ b/src/generated/rpg_mapinfo.cpp
@@ -17,7 +17,7 @@ RPG::MapInfo::MapInfo() {
 	name = "";
 	parent_map = 0;
 	indentation = 0;
-	type = 1;
+	type = -1;
 	scrollbar_x = 0;
 	scrollbar_y = 0;
 	expanded_node = false;

--- a/src/generated/rpg_savepartylocation.cpp
+++ b/src/generated/rpg_savepartylocation.cpp
@@ -27,7 +27,7 @@ RPG::SavePartyLocation::SavePartyLocation() {
 	overlap_forbidden = false;
 	animation_type = 1;
 	lock_facing = false;
-	move_speed = -1;
+	move_speed = 4;
 	move_route_overwrite = false;
 	move_route_index = 0;
 	move_route_repeated = false;

--- a/src/generated/rpg_savepartylocation.h
+++ b/src/generated/rpg_savepartylocation.h
@@ -27,7 +27,6 @@ namespace RPG {
 		};
 
 		SavePartyLocation();
-		void Fixup();
 
 		bool active;
 		int map_id;

--- a/src/generated/rpg_savescreen.cpp
+++ b/src/generated/rpg_savescreen.cpp
@@ -17,10 +17,10 @@ RPG::SaveScreen::SaveScreen() {
 	tint_finish_green = 100;
 	tint_finish_blue = 100;
 	tint_finish_sat = 100;
-	tint_current_red = -1.0;
-	tint_current_green = -1.0;
-	tint_current_blue = -1.0;
-	tint_current_sat = -1.0;
+	tint_current_red = 100.0;
+	tint_current_green = 100.0;
+	tint_current_blue = 100.0;
+	tint_current_sat = 100.0;
 	tint_time_left = 0;
 	flash_continuous = false;
 	flash_red = 0;

--- a/src/generated/rpg_savescreen.h
+++ b/src/generated/rpg_savescreen.h
@@ -16,7 +16,6 @@ namespace RPG {
 	class SaveScreen {
 	public:
 		SaveScreen();
-		void Fixup();
 
 		int tint_finish_red;
 		int tint_finish_green;

--- a/src/rpg_fixup.cpp
+++ b/src/rpg_fixup.cpp
@@ -128,24 +128,3 @@ void RPG::SaveMapInfo::Fixup(const RPG::Map& map) {
 		chipset_id = map.chipset_id;
 	}
 }
-
-void RPG::SavePartyLocation::Fixup() {
-	if (move_speed == -1) {
-		move_speed = 4;
-	}
-}
-
-void RPG::SaveScreen::Fixup() {
-	if (tint_current_red == -1.0) {
-		tint_current_red = 100.0;
-	}
-	if (tint_current_green == -1.0) {
-		tint_current_green = 100.0;
-	}
-	if (tint_current_blue == -1.0) {
-		tint_current_blue = 100.0;
-	}
-	if (tint_current_sat == -1.0) {
-		tint_current_sat = 100.0;
-	}
-}


### PR DESCRIPTION
This fixes a bug where using lcf2xml would corrupt the MapTree file, thanks to elsemieni for reporting it.