### PR TITLE
AnimationCellData fixes

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -51,10 +51,10 @@ AnimationCellData,cell_id,f,Integer,0x02,0,Integer
 AnimationCellData,x,f,Integer,0x03,0,Integer
 AnimationCellData,y,f,Integer,0x04,0,Integer
 AnimationCellData,zoom,f,Integer,0x05,100,Integer
-AnimationCellData,tone_red,f,Integer,0x06,0,Integer
-AnimationCellData,tone_green,f,Integer,0x07,0,Integer
-AnimationCellData,tone_blue,f,Integer,0x08,0,Integer
-AnimationCellData,tone_gray,f,Integer,0x09,0,Integer
+AnimationCellData,tone_red,f,Integer,0x06,100,Integer
+AnimationCellData,tone_green,f,Integer,0x07,100,Integer
+AnimationCellData,tone_blue,f,Integer,0x08,100,Integer
+AnimationCellData,tone_gray,f,Integer,0x09,100,Integer
 AnimationCellData,transparency,f,Integer,0x0A,0,Integer
 AnimationFrame,cells,f,Array<AnimationCellData>,0x01,,Array - RPG::AnimationCellData
 Animation,name,f,String,0x01,'',String

--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -46,7 +46,7 @@ AnimationTiming,flash_green,f,Integer,0x05,31,Integer
 AnimationTiming,flash_blue,f,Integer,0x06,31,Integer
 AnimationTiming,flash_power,f,Integer,0x07,31,Integer
 AnimationTiming,screen_shake,f,Enum<AnimationTiming_ScreenShake>,0x08,0,Integer - RPG2003 - TODO: Get chunk ID
-AnimationCellData,priority,f,Integer,0x01,1,Bool - TODO: Needs confirmation
+AnimationCellData,valid,f,Integer,0x01,1,Bool
 AnimationCellData,cell_id,f,Integer,0x02,0,Integer
 AnimationCellData,x,f,Integer,0x03,0,Integer
 AnimationCellData,y,f,Integer,0x04,0,Integer

--- a/src/generated/ldb_animationcelldata.cpp
+++ b/src/generated/ldb_animationcelldata.cpp
@@ -1,7 +1,7 @@
 /* !!!! GENERATED FILE - DO NOT EDIT !!!! */
 
 /*
- * Copyright (c) 2014 liblcf authors
+ * Copyright (c) 2015 liblcf authors
  * This file is released under the MIT License
  * http://opensource.org/licenses/MIT
  */
@@ -17,7 +17,7 @@
 #define LCF_CURRENT_STRUCT AnimationCellData
 
 LCF_STRUCT_FIELDS_BEGIN()
-	LCF_STRUCT_TYPED_FIELD(int, priority),
+	LCF_STRUCT_TYPED_FIELD(int, valid),
 	LCF_STRUCT_TYPED_FIELD(int, cell_id),
 	LCF_STRUCT_TYPED_FIELD(int, x),
 	LCF_STRUCT_TYPED_FIELD(int, y),

--- a/src/generated/ldb_chunks.h
+++ b/src/generated/ldb_chunks.h
@@ -125,8 +125,8 @@ namespace LDB_Reader {
 	};
 	struct ChunkAnimationCellData {
 		enum Index {
-			/** Bool - TODO: Needs confirmation */
-			priority		= 0x01,
+			/** Bool */
+			valid			= 0x01,
 			/** Integer */
 			cell_id			= 0x02,
 			/** Integer */

--- a/src/generated/rpg_animationcelldata.cpp
+++ b/src/generated/rpg_animationcelldata.cpp
@@ -1,7 +1,7 @@
 /* !!!! GENERATED FILE - DO NOT EDIT !!!! */
 
 /*
- * Copyright (c) 2014 liblcf authors
+ * Copyright (c) 2015 liblcf authors
  * This file is released under the MIT License
  * http://opensource.org/licenses/MIT
  */
@@ -19,9 +19,9 @@ RPG::AnimationCellData::AnimationCellData() {
 	x = 0;
 	y = 0;
 	zoom = 100;
-	tone_red = 0;
-	tone_green = 0;
-	tone_blue = 0;
-	tone_gray = 0;
+	tone_red = 100;
+	tone_green = 100;
+	tone_blue = 100;
+	tone_gray = 100;
 	transparency = 0;
 }

--- a/src/generated/rpg_animationcelldata.cpp
+++ b/src/generated/rpg_animationcelldata.cpp
@@ -14,7 +14,7 @@
  */
 RPG::AnimationCellData::AnimationCellData() {
 	ID = 0;
-	priority = 1;
+	valid = 1;
 	cell_id = 0;
 	x = 0;
 	y = 0;

--- a/src/generated/rpg_animationcelldata.h
+++ b/src/generated/rpg_animationcelldata.h
@@ -1,7 +1,7 @@
 /* !!!! GENERATED FILE - DO NOT EDIT !!!! */
 
 /*
- * Copyright (c) 2014 liblcf authors
+ * Copyright (c) 2015 liblcf authors
  * This file is released under the MIT License
  * http://opensource.org/licenses/MIT
  */
@@ -18,7 +18,7 @@ namespace RPG {
 		AnimationCellData();
 
 		int ID;
-		int priority;
+		int valid;
 		int cell_id;
 		int x;
 		int y;


### PR DESCRIPTION
Let's break the API again :D

This is a really bad one, because this results in completly wrong tone values being used in animations.
Also rename priority to valid, only valid cells are rendered.