### PR TITLE
Fix default passable_data_upper

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -104,7 +104,7 @@ Chipset,name,f,String,0x01,'',String
 Chipset,chipset_name,f,String,0x02,'',String
 Chipset,terrain_data,f,Vector<Int16>,0x03,[1]*162,Array - Short x 162
 Chipset,passable_data_lower,f,Vector<UInt8>,0x04,[15]*162,Array - Bitflag x 162
-Chipset,passable_data_upper,f,Vector<UInt8>,0x05,[15]*162,Array - Bitflag x 144
+Chipset,passable_data_upper,f,Vector<UInt8>,0x05,[31]+[15]*143,Array - Bitflag x 144
 Chipset,animation_type,f,Enum<Chipset_AnimType>,0x0B,0,Integer
 Chipset,animation_speed,f,Integer,0x0C,0,Integer
 Class,name,f,String,0x01,'',String

--- a/src/generated/lsd_chunks.h
+++ b/src/generated/lsd_chunks.h
@@ -629,7 +629,7 @@ namespace LSD_Reader {
 			actioned						= 0x0D,
 			/** size of the 0x16 vector: an array which stores the to be brought into an event code path FIXME */
 			unknown_15_subcommand_path_size	= 0x15,
-			/** byte Each indentation in the event code corresponds to an entry in the array. When a command such as e.g. Show Choice is achieved; stored in the array entry of the current level; which code path must accept the event. For example: if the player chooses the third entry is "3" (or maybe 2? not tested) stored there. When a "Case XXX" is achieved command; it is checked whether the value is stored there; the value of the "Case"-subcommand corresponds. Otherwise the block is skipped. If so then the block is executed and the stored value is set to 255 (probably a double protection if times; although that should never be more Case subcommands are with the same ID. FIXME */
+			/** byte Each indentation in the event code corresponds to an entry in the array. When a command such as e.g. Show Choice is achieved; stored in the array entry of the current level; which code path must accept the event. For example: if the player chooses the third entry is '3' (or maybe 2? not tested) stored there. When a 'Case XXX' is achieved command; it is checked whether the value is stored there; the value of the 'Case'-subcommand corresponds. Otherwise the block is skipped. If so then the block is executed and the stored value is set to 255 (probably a double protection if times; although that should never be more Case subcommands are with the same ID. FIXME */
 			unknown_16_subcommand_path		= 0x16 
 		};
 	};

--- a/src/rpg_setup.cpp
+++ b/src/rpg_setup.cpp
@@ -185,7 +185,8 @@ void RPG::MapInfo::Init() {
 void RPG::Chipset::Init() {
 	terrain_data.resize(162, 1);
 	passable_data_lower.resize(162, 15);
-	passable_data_upper.resize(162, 15);
+	passable_data_upper.resize(144, 15);
+	passable_data_upper.front() = 31;
 }
 
 void RPG::Parameters::Setup(int final_level) {


### PR DESCRIPTION
This fixes a bug where the player can walk over unpassable tiles, found in map 137 of The Gray Garden (thanks Mr.Faq2014 for reporting it) and map 342 of OFF.