### PR TITLE
Improve generator and a couple bug fixes

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -984,7 +984,7 @@ SaveEventData,commands,f,Array<SaveEventCommands>,0x01,,array FIXME what is the 
 SaveEventData,show_message,f,Boolean,0x04,False,Show Message command has been executed in the current move route
 SaveEventData,unknown_0d_move_waiting,f,Integer,0x0D,-1,flag which is set when the event is waiting for a move event. FIXME
 SaveEventData,keyinput_wait,f,Boolean,0x15,False,
-SaveEventData,keyinput_variable,f,Integer,0x16,-1,
+SaveEventData,keyinput_variable,f,UInt8,0x16,0,
 SaveEventData,keyinput_all_directions,f,Boolean,0x17,False,
 SaveEventData,keyinput_decision,f,Boolean,0x18,False,
 SaveEventData,keyinput_cancel,f,Boolean,0x19,False,
@@ -1061,7 +1061,7 @@ SaveEvents,events_size,f,Integer,0x04,0,int
 SaveEvents,unknown_0b_escape,f,Integer,0x0B,0,Flag which is set before a fight if the event is canceled by the struggle for escape. FIXME
 SaveEvents,unknown_0d_move_waiting,f,Integer,0x0D,0,Flag which is set when the event is waiting for a move event. FIXME
 SaveEvents,keyinput_wait,f,Boolean,0x15,False,
-SaveEvents,keyinput_variable,f,Integer,0x16,-1,
+SaveEvents,keyinput_variable,f,UInt8,0x16,0,
 SaveEvents,keyinput_all_directions,f,Boolean,0x17,False,
 SaveEvents,keyinput_decision,f,Boolean,0x18,False,
 SaveEvents,keyinput_cancel,f,Boolean,0x19,False,

--- a/src/generated/lsd_saveeventdata.cpp
+++ b/src/generated/lsd_saveeventdata.cpp
@@ -21,7 +21,7 @@ LCF_STRUCT_FIELDS_BEGIN()
 	LCF_STRUCT_TYPED_FIELD(bool, show_message),
 	LCF_STRUCT_TYPED_FIELD(int, unknown_0d_move_waiting),
 	LCF_STRUCT_TYPED_FIELD(bool, keyinput_wait),
-	LCF_STRUCT_TYPED_FIELD(int, keyinput_variable),
+	LCF_STRUCT_TYPED_FIELD(uint8_t, keyinput_variable),
 	LCF_STRUCT_TYPED_FIELD(bool, keyinput_all_directions),
 	LCF_STRUCT_TYPED_FIELD(bool, keyinput_decision),
 	LCF_STRUCT_TYPED_FIELD(bool, keyinput_cancel),

--- a/src/generated/lsd_saveevents.cpp
+++ b/src/generated/lsd_saveevents.cpp
@@ -22,7 +22,7 @@ LCF_STRUCT_FIELDS_BEGIN()
 	LCF_STRUCT_TYPED_FIELD(int, unknown_0b_escape),
 	LCF_STRUCT_TYPED_FIELD(int, unknown_0d_move_waiting),
 	LCF_STRUCT_TYPED_FIELD(bool, keyinput_wait),
-	LCF_STRUCT_TYPED_FIELD(int, keyinput_variable),
+	LCF_STRUCT_TYPED_FIELD(uint8_t, keyinput_variable),
 	LCF_STRUCT_TYPED_FIELD(bool, keyinput_all_directions),
 	LCF_STRUCT_TYPED_FIELD(bool, keyinput_decision),
 	LCF_STRUCT_TYPED_FIELD(bool, keyinput_cancel),

--- a/src/generated/rpg_saveeventdata.cpp
+++ b/src/generated/rpg_saveeventdata.cpp
@@ -16,7 +16,7 @@ RPG::SaveEventData::SaveEventData() {
 	show_message = false;
 	unknown_0d_move_waiting = -1;
 	keyinput_wait = false;
-	keyinput_variable = -1;
+	keyinput_variable = 0;
 	keyinput_all_directions = false;
 	keyinput_decision = false;
 	keyinput_cancel = false;

--- a/src/generated/rpg_saveeventdata.h
+++ b/src/generated/rpg_saveeventdata.h
@@ -11,6 +11,7 @@
 
 // Headers
 #include <vector>
+#include "reader_types.h"
 #include "rpg_saveeventcommands.h"
 
 /**
@@ -25,7 +26,7 @@ namespace RPG {
 		bool show_message;
 		int unknown_0d_move_waiting;
 		bool keyinput_wait;
-		int keyinput_variable;
+		uint8_t keyinput_variable;
 		bool keyinput_all_directions;
 		bool keyinput_decision;
 		bool keyinput_cancel;

--- a/src/generated/rpg_saveevents.cpp
+++ b/src/generated/rpg_saveevents.cpp
@@ -17,7 +17,7 @@ RPG::SaveEvents::SaveEvents() {
 	unknown_0b_escape = 0;
 	unknown_0d_move_waiting = 0;
 	keyinput_wait = false;
-	keyinput_variable = -1;
+	keyinput_variable = 0;
 	keyinput_all_directions = false;
 	keyinput_decision = false;
 	keyinput_cancel = false;

--- a/src/generated/rpg_saveevents.h
+++ b/src/generated/rpg_saveevents.h
@@ -11,6 +11,7 @@
 
 // Headers
 #include <vector>
+#include "reader_types.h"
 #include "rpg_saveeventcommands.h"
 
 /**
@@ -26,7 +27,7 @@ namespace RPG {
 		int unknown_0b_escape;
 		int unknown_0d_move_waiting;
 		bool keyinput_wait;
-		int keyinput_variable;
+		uint8_t keyinput_variable;
 		bool keyinput_all_directions;
 		bool keyinput_decision;
 		bool keyinput_cancel;

--- a/src/reader_struct.h
+++ b/src/reader_struct.h
@@ -198,7 +198,7 @@ struct Primitive<int> {
 		} else {
 			ref = 0;
 #ifdef LCF_DEBUG_TRACE
-			printf("Invalid integer at %s\n", stream->Tell());
+			printf("Invalid integer at %X\n", stream.Tell());
 #endif
 			stream.Seek(length, LcfReader::FromCurrent);
 		}


### PR DESCRIPTION
Instead of replacing all generated files each time generator.py is run, it'll replace now only files with changes by comparing them with a temporal generated file. That way, the compiler won't have to rebuild the whole project.