### PR TITLE
OS X: drop workaround for the old libstdc++ from Apple SDK

### DIFF
--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -184,9 +184,6 @@ std::string ReaderUtil::GetEncoding(const std::string& ini_file) {
 std::string ReaderUtil::GetLocaleEncoding() {
 #ifdef _WIN32
 	int codepage = GetACP();
-#elif defined(__APPLE__) && defined(__MACH__)
-	// libstdc++ does not support locale properly at least on OS X
-	int codepage = 0;
 #else
 	int codepage = 1252;
 


### PR DESCRIPTION
liblcf will use C++11 in future commits and Player already do, so old libstdc++ 4.2.1 is not working anymore

Build with clang and link with newer libstdc++, e.g. build g++ 5.2 and use its library to support older OS X versions because OS X clang's libc++ dropped OS X support < 10.7.