### PR TITLE
Correctly calculate size of RPG::EventCommand

### DIFF
--- a/src/ldb_eventcommand.cpp
+++ b/src/ldb_eventcommand.cpp
@@ -56,7 +56,7 @@ int RawStruct<RPG::EventCommand>::LcfSize(const RPG::EventCommand& event_command
 	int result = 0;
 	result += LcfReader::IntSize(event_command.code);
 	result += LcfReader::IntSize(event_command.indent);
-	result += LcfReader::IntSize(event_command.string.size());
+	result += LcfReader::IntSize(stream.Decode(event_command.string).size());
 	result += stream.Decode(event_command.string).size();
 	int count = event_command.parameters.size();
 	result += LcfReader::IntSize(count);


### PR DESCRIPTION
This should Fix https://github.com/EasyRPG/Player/issues/556

Can anybody else confirm this? Delete your old savegames, if they are already corrupted it won't help :D

Please also test: Save a game in the house with 1252 encoding. Then load it with 932 and save it.
It should still work (ICU substitutes invalid codepoints silently), at least for me.