### PR TITLE
Make reader_struct more fault tolerant and SaveActor::Fixup

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -1040,7 +1040,7 @@ SaveMapEvent,flash_current_level,f,Double,0x54,0.0,double
 SaveMapEvent,flash_time_left,f,Integer,0x55,0,int
 SaveMapEvent,running,f,Boolean,0x65,False,?
 SaveMapEvent,original_move_route_index,f,Integer,0x66,0,Index of custom move route
-SaveMapEvent,pending,f,Boolean,0x67,False,If true; this event will run after the current running event stops running
+SaveMapEvent,pending,f,Boolean,0x67,False,If true; this event will run after the current running event stops running. FIXME: See issue #174
 SaveMapEvent,event_data,f,SaveEventData,0x6C,,chunks
 SaveMapInfo,position_x,f,Integer,0x01,0,int
 SaveMapInfo,position_y,f,Integer,0x02,0,int

--- a/generator/csv/setup.csv
+++ b/generator/csv/setup.csv
@@ -4,7 +4,7 @@ Chipset,void Init(),
 MapInfo,void Init(),
 Save,void Setup(),
 SaveActor,void Setup(int actor_id),
-SaveActor,void Fixup(),
+SaveActor,void Fixup(int actor_id),
 SaveInventory,void Setup(),
 SaveMapEvent,void Setup(const RPG::Event& event),"rpg_event.h"
 SaveMapEvent,void Fixup(const RPG::EventPage& page),

--- a/src/generated/lsd_chunks.h
+++ b/src/generated/lsd_chunks.h
@@ -759,7 +759,7 @@ namespace LSD_Reader {
 			running						= 0x65,
 			/** Index of custom move route */
 			original_move_route_index	= 0x66,
-			/** If true; this event will run after the current running event stops running */
+			/** If true; this event will run after the current running event stops running. FIXME: See issue #174 */
 			pending						= 0x67,
 			/** chunks */
 			event_data					= 0x6C 

--- a/src/generated/rpg_saveactor.h
+++ b/src/generated/rpg_saveactor.h
@@ -21,7 +21,7 @@ namespace RPG {
 	class SaveActor {
 	public:
 		void Setup(int actor_id);
-		void Fixup();
+		void Fixup(int actor_id);
 
 		int ID = 0;
 		std::string name;

--- a/src/reader_struct.h
+++ b/src/reader_struct.h
@@ -136,9 +136,20 @@ struct LcfSizeT<bool> {
 template <class T>
 struct Primitive {
 	static void ReadLcf(T& ref, LcfReader& stream, uint32_t length) {
-		assert(length == LcfSizeT<T>::value);
+		int dif = 0;
+		// FIXME: Bug #174
+		if (length != LcfSizeT<T>::value) {
+			dif = length - LcfSizeT<T>::value;
+			fprintf(stderr, "Reading Primitive of incorrect size %d (expected %d) at %X\n",
+				length, LcfSizeT<T>::value, stream.Tell());
+		}
 
 		stream.Read(ref);
+
+		if (dif != 0) {
+			// Fix incorrect read pointer position
+			stream.Seek(dif, LcfReader::FromCurrent);
+		}
 	}
 	static void WriteLcf(const T& ref, LcfWriter& stream) {
 		stream.Write(ref);

--- a/src/rpg_fixup.cpp
+++ b/src/rpg_fixup.cpp
@@ -12,8 +12,10 @@
 #include "rpg_savemapinfo.h"
 #include "data.h"
 
-void RPG::SaveActor::Fixup() {
-	const RPG::Actor& actor = Data::actors[ID - 1];
+void RPG::SaveActor::Fixup(int actor_id) {
+	ID = actor_id;
+
+	const RPG::Actor& actor = Data::actors[actor_id - 1];
 
 	if (name == "\x1") {
 		name = actor.name;


### PR DESCRIPTION
This fixes problems with the savegame sent by K風鈴 (negima.0824@)

It doesn't load in RPG_RT but looks like a RPG_RT savegame. No idea what happened, the pending field has a strange size. Also the Actor IDs are wrong.

reader_struct realigns now the read pointer when the size is incorrect and shows an error message on the console when this happens.