### PR TITLE
MSVC: Switch to dynamic C runtime

### DIFF
--- a/builds/vs2015/PropertySheet.props
+++ b/builds/vs2015/PropertySheet.props
@@ -14,11 +14,11 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <StringPooling>true</StringPooling>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <ClCompile Condition="'$(Configuration)'=='Debug'">
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
 	  <PreprocessorDefinitions>DEBUG</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile>


### PR DESCRIPTION
I'm also currently switching the toolchain.

This adds a minor inconvenience to the user: They have to install the VS2015 runtime (not sure if it's distributed via windows update) once. They probably have an app already that did this for them.
This adds UWP support and makes the exe smaller.