### PR TITLE
Fix up SaveMapInfo.chipset_id value when equal or less than 0

### DIFF
--- a/src/rpg_fixup.cpp
+++ b/src/rpg_fixup.cpp
@@ -127,7 +127,7 @@ void RPG::SaveSystem::Fixup() {
 }
 
 void RPG::SaveMapInfo::Fixup(const RPG::Map& map) {
-	if (chipset_id == -1) {
+	if (chipset_id <= 0) {
 		chipset_id = map.chipset_id;
 	}
 }


### PR DESCRIPTION
This fixes a crash when loading some save files since EasyRPG/Player#979.