### PR TITLE
Change default value for animation_id of BattlerAnimationExtension to 1

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -92,7 +92,7 @@ BattlerAnimationExtension,name,f,String,0x01,'',String
 BattlerAnimationExtension,battler_name,f,String,0x02,'',String
 BattlerAnimationExtension,battler_index,f,Integer,0x03,0,Integer
 BattlerAnimationExtension,animation_type,f,Enum<BattlerAnimationExtension_AnimType>,0x04,0,Integer
-BattlerAnimationExtension,animation_id,f,Ref<Animation>,0x05,0,Integer
+BattlerAnimationExtension,animation_id,f,Ref<Animation>,0x05,1,Integer
 BattlerAnimation,name,f,String,0x01,'',String
 BattlerAnimation,speed,f,Enum<BattlerAnimation_Speed>,0x02,0,Integer
 BattlerAnimation,base_data,f,Array<BattlerAnimationExtension>,0x0A,,Array - RPG::BattlerAnimationExtension

--- a/src/generated/rpg_battleranimationextension.h
+++ b/src/generated/rpg_battleranimationextension.h
@@ -28,7 +28,7 @@ namespace RPG {
 		std::string battler_name;
 		int battler_index = 0;
 		int animation_type = 0;
-		int animation_id = 0;
+		int animation_id = 1;
 	};
 }
 


### PR DESCRIPTION
...Otherwise RPG2k3 games fail that use the first battle animation in "Animation 2"

Fixes EasyRPG/Player#1073