### PR TITLE
Fix #194 (heap corruption) and #196 (LcfWriter writing incorrect strings)

### DIFF
--- a/src/ldb_eventcommand.cpp
+++ b/src/ldb_eventcommand.cpp
@@ -45,7 +45,7 @@ void RawStruct<RPG::EventCommand>::WriteLcf(const RPG::EventCommand& event_comma
 	stream.Write(event_command.code);
 	stream.Write(event_command.indent);
 	stream.WriteInt(stream.Decode(event_command.string).size());
-	stream.Write(event_command.string);
+	stream.Write(stream.Decode(event_command.string));
 	int count = event_command.parameters.size();
 	stream.Write(count);
 	for (int i = 0; i < count; i++)

--- a/src/reader_lcf.cpp
+++ b/src/reader_lcf.cpp
@@ -160,10 +160,9 @@ void LcfReader::Read<uint32_t>(std::vector<uint32_t> &buffer, size_t size) {
 }
 
 void LcfReader::ReadString(std::string& ref, size_t size) {
-	char* chars = new char[size + 1];
-	chars[size] = '\0';
+	char* chars = new char[size];
 	Read(chars, 1, size);
-	ref = Encode(std::string(chars));
+	ref = Encode(std::string(chars, size));
 	delete[] chars;
 }
 


### PR DESCRIPTION
-