### PR TITLE
Fix savegame corruption introduced in 5abb593d

### DIFF
--- a/src/ldb_eventcommand.cpp
+++ b/src/ldb_eventcommand.cpp
@@ -48,7 +48,7 @@ void RawStruct<RPG::EventCommand>::WriteLcf(const RPG::EventCommand& event_comma
 	stream.Write(event_command.code);
 	stream.Write(event_command.indent);
 	stream.WriteInt(stream.Decode(event_command.string).size());
-	stream.Write(stream.Decode(event_command.string));
+	stream.Write(event_command.string);
 	int count = event_command.parameters.size();
 	stream.Write(count);
 	for (int i = 0; i < count; i++)

--- a/src/reader_lcf.cpp
+++ b/src/reader_lcf.cpp
@@ -56,7 +56,9 @@ void LcfReader::Read(void *ptr, size_t size, size_t nmemb) {
 #ifdef NDEBUG
 	Read0(ptr, size, nmemb);
 #else
-	assert(Read0(ptr, size, nmemb) == nmemb);
+	if (Read0(ptr, size, nmemb) != nmemb) {
+		fprintf(stderr, "Read error at %d. The file is probably corrupted\n", Tell());
+	}
 #endif
 }
 

--- a/src/reader_lcf.cpp
+++ b/src/reader_lcf.cpp
@@ -87,7 +87,7 @@ void LcfReader::Read<uint32_t>(uint32_t& ref) {
 int LcfReader::ReadInt() {
 	int value = 0;
 	unsigned char temp = 0;
-
+	int loops = 0;
 	do {
 		value <<= 7;
 		if (Read0(&temp, 1, 1) == 0) {
@@ -95,8 +95,14 @@ int LcfReader::ReadInt() {
 			return 0;
 		}
 		value |= temp & 0x7F;
+
+		if (loops > 5) {
+			fprintf(stderr, "Invalid compressed integer at %d\n", Tell());
+		}
+		++loops;
 	} while (temp & 0x80);
-	return value;
+
+	return loops > 5 ? 0 : value;
 }
 
 template <>
@@ -225,6 +231,9 @@ void LcfReader::SkipDebug(const struct LcfReader::Chunk& chunk_info, const char*
 		fprintf(stderr, "%02X ", byte);
 		if ((i+1) % 16 == 0) {
 			fprintf(stderr, "\n");
+		}
+		if (Eof()) {
+			break;
 		}
 	}
 	fprintf(stderr, "\n");


### PR DESCRIPTION
Removed the asserts and changed the error handling a bit because the broken event commands are reallllly bad and result in an assert when opening Scene_load or Scene_Save otherwise :(

Fixes EasyRPG/Player#1149.