### PR TITLE
Initialise font_id

### DIFF
--- a/src/rpg_setup.cpp
+++ b/src/rpg_setup.cpp
@@ -143,6 +143,7 @@ void RPG::SaveSystem::Setup() {
 	battle_end_fadeout = system.battle_end_fadeout;
 	battle_end_fadein = system.battle_end_fadein;
 	message_stretch = system.message_stretch;
+	font_id = system.font_id;
 	teleport_allowed = true;
 	escape_allowed = true;
 	save_allowed = true;


### PR DESCRIPTION
This is neccessary to allow setting the initial font in the database, needed for https://github.com/EasyRPG/Player/pull/1143