### PR TITLE
Fix ldb writing

### DIFF
--- a/builds/cmake/CMakeLists.txt
+++ b/builds/cmake/CMakeLists.txt
@@ -85,6 +85,9 @@ target_link_libraries(${PROJECT_NAME} ${ICU_LIBRARIES})
 find_package(Expat)
 include_directories(${EXPAT_INCLUDE_DIR})
 target_link_libraries(${PROJECT_NAME} ${EXPAT_LIBRARY})
+if (${EXPAT_FOUND})
+  add_definitions(-DLCF_SUPPORT_XML)
+endif()
 
 # installation
 set(LIB_INSTALL_DIR "lib" CACHE STRING "The install directory for libraries")


### PR DESCRIPTION
Like RPG::Save, RPG::Database has one 0-byte too much.
Merged RPG::Save & Database logic because I understood in the meanwhile how templates + type_traits work ;)

No idea if this is related to #196 

Now lcf2xml is finally more usable \o/

Better diff:

```diff
+template<typename T>
+typename std::enable_if<std::is_same<T, RPG::Save>::value ||
+		std::is_same<T, RPG::Database>::value>::type
+conditional_zero_writer(LcfWriter&) {
+	// no-op
+};
+
+template<typename T>
+typename std::enable_if<!std::is_same<T, RPG::Save>::value &&
+						!std::is_same<T, RPG::Database>::value>::type
+conditional_zero_writer(LcfWriter& stream) {
+	stream.WriteInt(0);
+};
+
 template <class S>
 void Struct<S>::WriteLcf(const S& obj, LcfWriter& stream) {
 	S ref = S();
 	int last = -1;
 	for (int i = 0; fields[i] != NULL; i++) {
 		const Field<S>* field = fields[i];
 		if (field->id < last)
 			std::cerr << "field order mismatch: " << field->id
 					  << " after " << last
 					  << " in struct " << name
 					  << std::endl;
-		//printf("\n%s", field->name);
 		if (field->IsDefault(obj, ref)) {
-			//printf(" -> default");
 			continue;
 		}
 		stream.WriteInt(field->id);
 		stream.WriteInt(field->LcfSize(obj, stream));
 		field->WriteLcf(obj, stream);
 	}
+	// Writing a 0-byte after RPG::Database or RPG::Save breaks the parser in RPG_RT
+	conditional_zero_writer<S>(stream);
}
-
-template <>
-void Struct<RPG::Save>::WriteLcf(const RPG::Save& obj, LcfWriter& stream) {
-	RPG::Save ref = RPG::Save();
-	int last = -1;
-	for (int i = 0; fields[i] != NULL; i++) {
-		const Field<RPG::Save>* field = fields[i];
-		if (field->id < last)
-			std::cerr << "field order mismatch: " << field->id
-					  << " after " << last
-					  << " in struct " << name
-					  << std::endl;
-		//printf("\n%s", field->name);
-		if (field->IsDefault(obj, ref)) {
-			//printf(" -> default");
-			continue;
-		}
-		stream.WriteInt(field->id);
-		stream.WriteInt(field->LcfSize(obj, stream));
-		field->WriteLcf(obj, stream);
-	}
-	// stream.WriteInt(0); // This last byte broke savegames
-}
```