### PR TITLE
When message stretch is missing in the savegame use db value

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -706,7 +706,7 @@ SaveTitle,face4_id,f,Integer,0x1C,0,int: face id
 SaveSystem,screen,f,Integer,0x01,1,
 SaveSystem,frame_count,f,Integer,0x0B,0,
 SaveSystem,graphics_name,f,String,0x15,'',string
-SaveSystem,message_stretch,f,Integer,0x16,0,Integer
+SaveSystem,message_stretch,f,Integer,0x16,-1,Integer
 SaveSystem,font_id,f,Integer,0x17,0,Integer
 SaveSystem,switches_size,f,Integer,0x1F,0,
 SaveSystem,switches,f,Vector<Boolean>,0x20,,

--- a/src/generated/rpg_savesystem.h
+++ b/src/generated/rpg_savesystem.h
@@ -35,7 +35,7 @@ namespace RPG {
 		int screen = 1;
 		int frame_count = 0;
 		std::string graphics_name;
-		int message_stretch = 0;
+		int message_stretch = -1;
 		int font_id = 0;
 		int switches_size = 0;
 		std::vector<bool> switches;

--- a/src/rpg_fixup.cpp
+++ b/src/rpg_fixup.cpp
@@ -127,6 +127,9 @@ void RPG::SaveSystem::Fixup() {
 	if (item_se.name.empty()) {
 		item_se.name = system.item_se.name;
 	}
+	if (message_stretch == -1) {
+		message_stretch = system.message_stretch;
+	}
 }
 
 void RPG::SaveMapInfo::Fixup(const RPG::Map& map) {


### PR DESCRIPTION
Fix https://github.com/EasyRPG/Player/issues/1230

This results in wrong tiling in the GameBrowser.

Patch for GameBrowser:
```diff
diff --git a/src/scene_gamebrowser.cpp b/src/scene_gamebrowser.cpp
index 1ce12b47..99e292ad 100644
--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -41,6 +41,7 @@ Scene_GameBrowser::Scene_GameBrowser() {
 
 void Scene_GameBrowser::Start() {
 	Game_System::SetSystemName(CACHE_DEFAULT_BITMAP);
+	Game_System::SetMessageStretch(RPG::System::Stretch_stretch);
 	CreateWindows();
 	Player::FrameReset();
 }
```