### PR TITLE
Fixes for GCC 4.8.x

### DIFF
--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -31,6 +31,7 @@
 #   include <locale>
 #endif
 
+#include <cstdio>
 #include <cstdlib>
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
These small changes (just adding #include <stdio.h> to 2 files) are required for GCC 4.8.x, which happens to be the default GCC version for the GCW0. (Yes, they're still stuck with that old version)

Without this pr, i get undefined references to fprintf.