### PR TITLE
Exchange State's HP and SP map damage data (val <-> steps)

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -371,12 +371,12 @@ State,message_affected,f,String,0x36,'',String
 State,message_recovery,f,String,0x37,'',String
 State,hp_change_max,f,Int32,0x3D,0,Integer
 State,hp_change_val,f,Int32,0x3E,0,Integer
-State,hp_change_map_val,f,Int32,0x3F,0,Integer
-State,hp_change_map_steps,f,Int32,0x40,0,Integer
+State,hp_change_map_steps,f,Int32,0x3F,0,Integer
+State,hp_change_map_val,f,Int32,0x40,0,Integer
 State,sp_change_max,f,Int32,0x41,0,Integer
 State,sp_change_val,f,Int32,0x42,0,Integer
-State,sp_change_map_val,f,Int32,0x43,0,Integer
-State,sp_change_map_steps,f,Int32,0x44,0,Integer
+State,sp_change_map_steps,f,Int32,0x43,0,Integer
+State,sp_change_map_val,f,Int32,0x44,0,Integer
 Terms,encounter,f,String,0x01,'',String
 Terms,special_combat,f,String,0x02,'',String
 Terms,escape_success,f,String,0x03,'',String

--- a/src/generated/ldb_chunks.h
+++ b/src/generated/ldb_chunks.h
@@ -867,17 +867,17 @@ namespace LDB_Reader {
 			/** Integer */
 			hp_change_val = 0x3E,
 			/** Integer */
-			hp_change_map_val = 0x3F,
+			hp_change_map_steps = 0x3F,
 			/** Integer */
-			hp_change_map_steps = 0x40,
+			hp_change_map_val = 0x40,
 			/** Integer */
 			sp_change_max = 0x41,
 			/** Integer */
 			sp_change_val = 0x42,
 			/** Integer */
-			sp_change_map_val = 0x43,
+			sp_change_map_steps = 0x43,
 			/** Integer */
-			sp_change_map_steps = 0x44
+			sp_change_map_val = 0x44
 		};
 	};
 	struct ChunkTerms {

--- a/src/generated/ldb_state.cpp
+++ b/src/generated/ldb_state.cpp
@@ -56,12 +56,12 @@ LCF_STRUCT_FIELDS_BEGIN()
 	LCF_STRUCT_TYPED_FIELD(std::string, message_recovery),
 	LCF_STRUCT_TYPED_FIELD(int32_t, hp_change_max),
 	LCF_STRUCT_TYPED_FIELD(int32_t, hp_change_val),
-	LCF_STRUCT_TYPED_FIELD(int32_t, hp_change_map_val),
 	LCF_STRUCT_TYPED_FIELD(int32_t, hp_change_map_steps),
+	LCF_STRUCT_TYPED_FIELD(int32_t, hp_change_map_val),
 	LCF_STRUCT_TYPED_FIELD(int32_t, sp_change_max),
 	LCF_STRUCT_TYPED_FIELD(int32_t, sp_change_val),
-	LCF_STRUCT_TYPED_FIELD(int32_t, sp_change_map_val),
 	LCF_STRUCT_TYPED_FIELD(int32_t, sp_change_map_steps),
+	LCF_STRUCT_TYPED_FIELD(int32_t, sp_change_map_val),
 LCF_STRUCT_FIELDS_END()
 
 #undef LCF_CURRENT_STRUCT

--- a/src/generated/rpg_state.h
+++ b/src/generated/rpg_state.h
@@ -80,12 +80,12 @@ namespace RPG {
 		std::string message_recovery;
 		int32_t hp_change_max = 0;
 		int32_t hp_change_val = 0;
-		int32_t hp_change_map_val = 0;
 		int32_t hp_change_map_steps = 0;
+		int32_t hp_change_map_val = 0;
 		int32_t sp_change_max = 0;
 		int32_t sp_change_val = 0;
-		int32_t sp_change_map_val = 0;
 		int32_t sp_change_map_steps = 0;
+		int32_t sp_change_map_val = 0;
 	};
 }
 


### PR DESCRIPTION
Exchange State->hp_change_map_steps and State->hp_change_map_val, and State->sp_change_map_steps and State->sp_change_map_val.

Problem: The data saved in each pair was supposed to be in the other.