### PR TITLE
Include stdio unconditionally in reader_lcf.cpp

### DIFF
--- a/src/reader_lcf.cpp
+++ b/src/reader_lcf.cpp
@@ -8,12 +8,10 @@
  */
 
 #include <cstdarg>
+#include <cstdio>
 #include <istream>
 
 #include "reader_lcf.h"
-#ifndef NDEBUG
-#  include <stdio.h>
-#endif
 
 // Statics
 
@@ -35,7 +33,7 @@ size_t LcfReader::Read0(void *ptr, size_t size, size_t nmemb) {
 	//Read nmemb elements of size and return the number of read elements
 	stream.read(reinterpret_cast<char*>(ptr), size*nmemb);
 	size_t result = stream.gcount() / size;
-#ifndef NDEBUG
+#ifdef NDEBUG
 	if (result != nmemb && !Eof()) {
 		perror("Reading error: ");
 	}

--- a/src/reader_lcf.cpp
+++ b/src/reader_lcf.cpp
@@ -11,7 +11,7 @@
 #include <istream>
 
 #include "reader_lcf.h"
-#ifdef NDEBUG
+#ifndef NDEBUG
 #  include <stdio.h>
 #endif
 
@@ -35,7 +35,7 @@ size_t LcfReader::Read0(void *ptr, size_t size, size_t nmemb) {
 	//Read nmemb elements of size and return the number of read elements
 	stream.read(reinterpret_cast<char*>(ptr), size*nmemb);
 	size_t result = stream.gcount() / size;
-#ifdef NDEBUG
+#ifndef NDEBUG
 	if (result != nmemb && !Eof()) {
 		perror("Reading error: ");
 	}


### PR DESCRIPTION
In reader_lcf.cpp stdio.h only got included when NDEBUG was defined, but it should be the other way around. 