### PR TITLE
 Make liblcf compile on MorphOS and AmigaOS4 

### DIFF
--- a/src/reader_lcf.cpp
+++ b/src/reader_lcf.cpp
@@ -8,12 +8,10 @@
  */
 
 #include <cstdarg>
+#include <cstdio>
 #include <istream>
 
 #include "reader_lcf.h"
-#ifndef NDEBUG
-#  include <stdio.h>
-#endif
 
 // Statics
 
@@ -35,7 +33,7 @@ size_t LcfReader::Read0(void *ptr, size_t size, size_t nmemb) {
 	//Read nmemb elements of size and return the number of read elements
 	stream.read(reinterpret_cast<char*>(ptr), size*nmemb);
 	size_t result = stream.gcount() / size;
-#ifndef NDEBUG
+#ifdef NDEBUG
 	if (result != nmemb && !Eof()) {
 		perror("Reading error: ");
 	}

--- a/src/reader_lcf.cpp
+++ b/src/reader_lcf.cpp
@@ -11,7 +11,7 @@
 #include <istream>
 
 #include "reader_lcf.h"
-#ifdef NDEBUG
+#ifndef NDEBUG
 #  include <stdio.h>
 #endif
 
@@ -35,7 +35,7 @@ size_t LcfReader::Read0(void *ptr, size_t size, size_t nmemb) {
 	//Read nmemb elements of size and return the number of read elements
 	stream.read(reinterpret_cast<char*>(ptr), size*nmemb);
 	size_t result = stream.gcount() / size;
-#ifdef NDEBUG
+#ifndef NDEBUG
 	if (result != nmemb && !Eof()) {
 		perror("Reading error: ");
 	}

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -31,6 +31,10 @@
 #   include <locale>
 #endif
 
+#if defined(__MORPHOS__) || defined(__amigaos4__)
+#define ICONV_CONST const
+#endif
+
 #include <cstdio>
 #include <cstdlib>
 #include <sstream>

--- a/src/writer_xml.cpp
+++ b/src/writer_xml.cpp
@@ -9,6 +9,10 @@
 
 #include <ostream>
 #include <vector>
+#if defined(__amigaos4__) && defined(__NEWLIB__) && defined(__STRICT_ANSI__)
+#define snprintf(str, size, format, ...) sprintf((str), (format), __VA_ARGS__)
+#endif
+
 #include "writer_xml.h"
 
 XmlWriter::XmlWriter(std::ostream& filestream) :


### PR DESCRIPTION
The library now builds for MorphOS and AmigaOS4 with autotools.