### PR TITLE
Add support for writing empty RM2k arrays for Actor

### DIFF
--- a/src/reader_struct.cpp
+++ b/src/reader_struct.cpp
@@ -36,6 +36,22 @@ void Struct<S>::MakeTagMap() {
 		tag_map[fields[i]->name] = fields[i];
 }
 
+template <typename T>
+struct StructDefault {
+    static T make() {
+        return T();
+    }
+};
+
+template <>
+struct StructDefault<RPG::Actor> {
+    static RPG::Actor make() {
+        auto actor = RPG::Actor();
+        actor.Setup();
+        return actor;
+    }
+};
+
 template <class S>
 void Struct<S>::ReadLcf(S& obj, LcfReader& stream) {
 	MakeFieldMap();
@@ -79,7 +95,7 @@ conditional_zero_writer(LcfWriter& stream) {
 
 template <class S>
 void Struct<S>::WriteLcf(const S& obj, LcfWriter& stream) {
-	S ref = S();
+	auto ref = StructDefault<S>::make();
 	int last = -1;
 	for (int i = 0; fields[i] != NULL; i++) {
 		const Field<S>* field = fields[i];
@@ -102,7 +118,7 @@ void Struct<S>::WriteLcf(const S& obj, LcfWriter& stream) {
 template <class S>
 int Struct<S>::LcfSize(const S& obj, LcfWriter& stream) {
 	int result = 0;
-	S ref = S();
+	auto ref = StructDefault<S>::make();
 	for (int i = 0; fields[i] != NULL; i++) {
 		const Field<S>* field = fields[i];
 		//printf("%s\n", field->name);


### PR DESCRIPTION
The first commit is part of the other PR, can ignore it here.

This commit creates a `FieldDefaultWriter` mechanism for writing empty arrays. I've implemented support for Actor skills, states, and attributes. 

This is going the approach of manually adding each array. These arrays seems to have all different conventions, so I'm not sure how easy it would be to generate this from a script.
Also, the complete solution would need to check whether it's rm2k or 2k3 mode. If its rm2k mode, the 2k3 arrays must not be written.

Related to #229 and #234