### PR TITLE
Fix warnings with LCF_DEBUG_TRACE

### DIFF
--- a/src/reader_struct.h
+++ b/src/reader_struct.h
@@ -181,7 +181,7 @@ struct Primitive<std::vector<T>> {
 		typename std::vector<T>::iterator it;
 		printf("  ");
 		for (it = ref.begin(); it != ref.end(); ++it) {
-			printf("%d, ", *it);
+			printf("%d, ", static_cast<int>(*it));
 		}
 		printf("\n");
 #endif


### PR DESCRIPTION
Fixes a warning with `vector<bool>` bit reference and `%d` in printf.