### PR TITLE
Correct defaults for Terrain grid a/b/c

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -332,9 +332,9 @@ Terrain,special_back_enemies,f,Int32,0x2A,10,Integer - RPG2003
 Terrain,special_lateral_party,f,Int32,0x2B,10,Integer - RPG2003
 Terrain,special_lateral_enemies,f,Int32,0x2C,5,Integer - RPG2003
 Terrain,grid_location,f,Int32,0x2D,0,Integer - RPG2003
-Terrain,grid_a,f,Int32,0x2E,0,Integer - RPG2003
-Terrain,grid_b,f,Int32,0x2F,0,Integer - RPG2003
-Terrain,grid_c,f,Int32,0x30,0,Integer - RPG2003
+Terrain,grid_a,f,Int32,0x2E,120,Integer - RPG2003
+Terrain,grid_b,f,Int32,0x2F,392,Integer - RPG2003
+Terrain,grid_c,f,Int32,0x30,16000,Integer - RPG2003
 State,name,f,String,0x01,'',String
 State,type,f,Enum<State_Persistence>,0x02,0,Integer
 State,color,f,Int32,0x03,6,Integer

--- a/src/generated/rpg_terrain.h
+++ b/src/generated/rpg_terrain.h
@@ -69,9 +69,9 @@ namespace RPG {
 		int32_t special_lateral_party = 10;
 		int32_t special_lateral_enemies = 5;
 		int32_t grid_location = 0;
-		int32_t grid_a = 0;
-		int32_t grid_b = 0;
-		int32_t grid_c = 0;
+		int32_t grid_a = 120;
+		int32_t grid_b = 392;
+		int32_t grid_c = 16000;
 	};
 }
 


### PR DESCRIPTION
Should also fix bugs in Player where terrain defaults to 0,0,0 and actors are ontop of each other.