### PR TITLE
Detect corrupted chunks and reset the parser

### DIFF
--- a/src/reader_struct.cpp
+++ b/src/reader_struct.cpp
@@ -73,10 +73,18 @@ void Struct<S>::ReadLcf(S& obj, LcfReader& stream) {
 #ifdef LCF_DEBUG_TRACE
 			printf("0x%02x (size: %d, pos: 0x%x): %s\n", chunk_info.ID, chunk_info.length, stream.Tell(), it->second->name);
 #endif
+			const auto off = stream.Tell();
 			it->second->ReadLcf(obj, stream, chunk_info.length);
+			const auto bytes_read = stream.Tell() - off;
+			if (bytes_read != chunk_info.length) {
+				fprintf(stderr, "Warning: Corrupted Chunk 0x%02x (size: %d, pos: 0x%x): %s : Read %d bytes! Reseting...\n",
+						chunk_info.ID, chunk_info.length, off, it->second->name, bytes_read);
+				stream.Seek(off + chunk_info.length);
+			}
 		}
-		else
+		else {
 			stream.Skip(chunk_info);
+		}
 	}
 }
 


### PR DESCRIPTION
Towards addressing #249 

This one successfully parses the Devil and Angel ldb. When I copy it, the chunk for the corrupted animation is different, but everything else in the database is a perfect match.

This and other games like like it should load and be playable now in Player.

This doesn't attempt to emulate how rm2k/3 interprets the corrupted chunk.