### PR TITLE
Fix vs2015 build

### DIFF
--- a/builds/vs2015/liblcf.vcxproj
+++ b/builds/vs2015/liblcf.vcxproj
@@ -262,6 +262,7 @@
     <ClCompile Include="..\..\src\generated\lsd_savevehiclelocation.cpp" />
     <ClCompile Include="..\..\src\generated\rpg_chipset.cpp" />
     <ClCompile Include="..\..\src\generated\rpg_mapinfo.cpp" />
+    <ClCompile Include="..\..\src\generated\rpg_system.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\command_codes.h" />


### PR DESCRIPTION
The build for Player is broken for windows because the vs project of liblcf is missing `rpg_system.cpp`