### PR TITLE
 Increment save counts when writing LDB, LMU, and LSD 

### DIFF
--- a/src/ldb_reader.cpp
+++ b/src/ldb_reader.cpp
@@ -17,6 +17,10 @@
 #include "reader_util.h"
 #include "reader_struct.h"
 
+void LDB_Reader::PrepareSave(RPG::Database& db) {
+	++db.system.save_count;
+}
+
 bool LDB_Reader::Load(const std::string& filename, const std::string& encoding) {
 	std::ifstream stream(filename.c_str(), std::ios::binary);
 	if (!stream.is_open()) {

--- a/src/ldb_reader.h
+++ b/src/ldb_reader.h
@@ -42,6 +42,11 @@
  */
 namespace LDB_Reader {
 	/**
+	 * Increment the database save_count.
+	 */
+	void PrepareSave(RPG::Database& db);
+
+	/**
 	 * Loads Database.
 	 */
 	bool Load(const std::string& filename, const std::string& encoding);

--- a/src/lmu_reader.cpp
+++ b/src/lmu_reader.cpp
@@ -17,6 +17,10 @@
 #include "reader_util.h"
 #include "reader_struct.h"
 
+void LMU_Reader::PrepareSave(RPG::Map& map) {
+	++map.save_count;
+}
+
 std::unique_ptr<RPG::Map> LMU_Reader::Load(const std::string& filename, const std::string& encoding) {
 	std::ifstream stream(filename.c_str(), std::ios::binary);
 	if (!stream.is_open()) {

--- a/src/lmu_reader.h
+++ b/src/lmu_reader.h
@@ -21,6 +21,11 @@
 namespace LMU_Reader {
 
 	/**
+	 * Increment the map save count.
+	 */
+	void PrepareSave(RPG::Map& map);
+
+	/**
 	 * Loads map.
 	 */
 	std::unique_ptr<RPG::Map> Load(const std::string& filename, const std::string& encoding);

--- a/src/lsd_reader.cpp
+++ b/src/lsd_reader.cpp
@@ -19,7 +19,6 @@
 #include "reader_util.h"
 #include "reader_struct.h"
 
-
 double LSD_Reader::ToTDateTime(std::time_t const t) {
 	// 25569 is UnixDateDelta: number of days between 1970-01-01 and 1900-01-01
 	return(t / 86400.0 + 25569.0);
@@ -32,6 +31,12 @@ std::time_t LSD_Reader::ToUnixTimestamp(double const ms) {
 double LSD_Reader::GenerateTimestamp(std::time_t const t) {
 	return ToTDateTime(t);
 }
+
+void LSD_Reader::PrepareSave(RPG::Save& save) {
+	++save.system.save_count;
+	save.title.timestamp = LSD_Reader::GenerateTimestamp();
+}
+
 
 std::unique_ptr<RPG::Save> LSD_Reader::Load(const std::string& filename, const std::string& encoding) {
 	std::ifstream stream(filename.c_str(), std::ios::binary);

--- a/src/lsd_reader.h
+++ b/src/lsd_reader.h
@@ -37,6 +37,11 @@ namespace LSD_Reader {
 	double GenerateTimestamp(std::time_t const t = std::time(NULL));
 
 	/**
+	 * Increment the save save_count and update the timestamp.
+	 */
+	void PrepareSave(RPG::Save& save);
+
+	/**
 	 * Loads Savegame.
 	 */
 	std::unique_ptr<RPG::Save> Load(const std::string& filename, const std::string &encoding);


### PR DESCRIPTION
Depends on: #264

This patch changes *_Reader::Save() to automatically increment `save_count` before writing the file.

There is a new `SaveOpt::eNoIncSaveCount` you can pass to suppress this behavior.

I also added `SaveOpt::eNoUdate` value which is intended to combine all of the `SaveOpt`'s required for copying lcf files without modifications. We should use this `SaveOpt` for our testing liblcf.

This will fix bugs in Player and Editor related to save counts.
