### PR TITLE
Add cmake config to autotools-based installs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,10 @@ pkgconfigdir = ${libdir}/pkgconfig
 pkgconfig_DATA = builds/liblcf.pc
 
 cmakeconfigdir = $(libdir)/cmake/liblcf
-cmakeconfig_DATA = builds/liblcf-config.cmake
+cmakeconfig_DATA = \
+	builds/liblcf-config.cmake \
+	builds/cmake/Modules/FindEXPAT.cmake \
+	builds/cmake/Modules/FindICU.cmake
 
 lib_LTLIBRARIES = liblcf.la
 liblcf_la_CPPFLAGS = \

--- a/builds/liblcf-config.cmake.in
+++ b/builds/liblcf-config.cmake.in
@@ -66,6 +66,11 @@ if(LIBLCF_FOUND)
 	if(NOT TARGET liblcf::liblcf)
 		add_library(liblcf::liblcf UNKNOWN IMPORTED)
 
+		if(${CMAKE_VERSION} VERSION_LESS "3.10")
+			include("${CMAKE_CURRENT_LIST_DIR}/FindICU.cmake")
+			include("${CMAKE_CURRENT_LIST_DIR}/FindEXPAT.cmake")
+		endif()
+
 		set(LIBLCF_LIBRARY_DEPS "@AX_PACKAGE_REQUIRES_PRIVATE@")
 		string(REPLACE " " ";" LIBLCF_LIBRARY_DEPS "${LIBLCF_LIBRARY_DEPS}")
 


### PR DESCRIPTION
Fixes an issue where an old cmake version (<3.10) will not compile
Player, because the needed EXPAT::EXPAT target is not available.