### PR TITLE
Fix SaveActor::row

### DIFF
--- a/generator/csv/enums.csv
+++ b/generator/csv/enums.csv
@@ -114,6 +114,8 @@ Terrain,BushDepth,half,2
 Terrain,BushDepth,full,3
 Terrain,BGAssociation,background,0
 Terrain,BGAssociation,frame,1
+SaveActor,RowType,front,0
+SaveActor,RowType,back,1
 SavePartyLocation,VehicleType,none,0
 SavePartyLocation,VehicleType,skiff,1
 SavePartyLocation,VehicleType,ship,2

--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -953,7 +953,7 @@ SaveActor,status,t,Count<Int16>,0x51,0,0,0,?
 SaveActor,status,f,Vector<Int16>,0x52,,1,0,array of short
 SaveActor,changed_battle_commands,f,Boolean,0x53,False,0,0,bool
 SaveActor,class_id,f,Ref<Class>,0x5A,-1,0,0,int class-id
-SaveActor,row,f,Int32,0x5B,0,0,1,RPG2003 Battle row (-1 Back; 1 Front)
+SaveActor,row,f,Enum<SaveActor_RowType>,0x5B,0,0,1,RPG2003 Battle row
 SaveActor,two_weapon,f,Boolean,0x5C,False,0,0,bool
 SaveActor,lock_equipment,f,Boolean,0x5D,False,0,0,bool
 SaveActor,auto_battle,f,Boolean,0x5E,False,0,0,bool

--- a/src/generated/lsd_chunks.h
+++ b/src/generated/lsd_chunks.h
@@ -562,7 +562,7 @@ namespace LSD_Reader {
 			changed_battle_commands = 0x53,
 			/** int class-id */
 			class_id = 0x5A,
-			/** RPG2003 Battle row (-1 Back; 1 Front) */
+			/** RPG2003 Battle row */
 			row = 0x5B,
 			/** bool */
 			two_weapon = 0x5C,

--- a/src/generated/rpg_enums.cpp
+++ b/src/generated/rpg_enums.cpp
@@ -35,6 +35,7 @@
 #include "rpg_savepicture.h"
 #include "rpg_savepartylocation.h"
 #include "rpg_savevehiclelocation.h"
+#include "rpg_saveactor.h"
 #include "rpg_mapinfo.h"
 #include "rpg_treemap.h"
 
@@ -102,6 +103,7 @@ constexpr decltype(SavePicture::kBattleLayerTags) SavePicture::kBattleLayerTags;
 constexpr decltype(SavePartyLocation::kVehicleTypeTags) SavePartyLocation::kVehicleTypeTags;
 constexpr decltype(SavePartyLocation::kPanStateTags) SavePartyLocation::kPanStateTags;
 constexpr decltype(SaveVehicleLocation::kVehicleTypeTags) SaveVehicleLocation::kVehicleTypeTags;
+constexpr decltype(SaveActor::kRowTypeTags) SaveActor::kRowTypeTags;
 constexpr decltype(MapInfo::kMusicTypeTags) MapInfo::kMusicTypeTags;
 constexpr decltype(MapInfo::kBGMTypeTags) MapInfo::kBGMTypeTags;
 constexpr decltype(MapInfo::kTriStateTags) MapInfo::kTriStateTags;

--- a/src/generated/rpg_saveactor.h
+++ b/src/generated/rpg_saveactor.h
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include "enum_tags.h"
 
 /**
  * RPG::SaveActor class.
@@ -23,6 +24,15 @@
 namespace RPG {
 	class SaveActor {
 	public:
+		enum RowType {
+			RowType_front = 0,
+			RowType_back = 1
+		};
+		static constexpr auto kRowTypeTags = makeEnumTags<RowType>(
+			"front",
+			"back"
+		);
+
 		void Setup(int actor_id);
 		void Fixup(int actor_id);
 		void UnFixup();

--- a/src/rpg_setup.cpp
+++ b/src/rpg_setup.cpp
@@ -50,7 +50,6 @@ void RPG::SaveActor::Setup(int actor_id) {
 	status.resize(Data::states.size());
 	changed_battle_commands = false;
 	class_id = -1;
-	row = -1;
 	two_weapon = actor.two_weapon;
 	lock_equipment = actor.lock_equipment;
 	auto_battle = actor.auto_battle;


### PR DESCRIPTION
Changed it to an enum. The values I use are:
* 0 - front
* 1 - back

How did we come up with -1 meaning front, 1 back, and 0 being a meaningless default? Since the row chunk is not present in save data when defaulted, there doesn't seem anyway to know what the front value is in `RPG_RT` without looking at process memory, but I can't see why it would be -1.