### PR TITLE
Add support for generated constants in RPG:: classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,8 @@ add_library(lcf
 	src/generated/lsd_savevehiclelocation.cpp
 	src/generated/rpg_chipset.cpp
 	src/generated/rpg_enums.cpp
+	src/generated/rpg_savepartylocation.cpp
+	src/generated/rpg_state.cpp
 	src/generated/rpg_system.cpp
 )
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,8 @@ liblcf_la_SOURCES = \
 	src/generated/lsd_savevehiclelocation.cpp \
 	src/generated/rpg_chipset.cpp \
 	src/generated/rpg_enums.cpp \
+	src/generated/rpg_savepartylocation.cpp \
+	src/generated/rpg_state.cpp \
 	src/generated/rpg_system.cpp
 pkginclude_HEADERS = \
 	src/command_codes.h \

--- a/builds/vs2015/liblcf.vcxproj
+++ b/builds/vs2015/liblcf.vcxproj
@@ -264,6 +264,8 @@
     <ClCompile Include="..\..\src\generated\lsd_savetitle.cpp" />
     <ClCompile Include="..\..\src\generated\lsd_savevehiclelocation.cpp" />
     <ClCompile Include="..\..\src\generated\rpg_chipset.cpp" />
+    <ClCompile Include="..\..\src\generated\rpg_savepartylocation.cpp" />
+    <ClCompile Include="..\..\src\generated\rpg_state.cpp" />
     <ClCompile Include="..\..\src\generated\rpg_system.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/generator/csv/constants.csv
+++ b/generator/csv/constants.csv
@@ -1,0 +1,4 @@
+#Structure,name,type,value,comment
+State,kDeathID,int,1,The ID of the special death state
+SavePartyLocation,kPanXDefault,int,9 * 256,Equal to 9 tiles in 1/16th pixels
+SavePartyLocation,kPanYDefault,int,7 * 256,Equal to 7 tiles in 1/16th pixels

--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -837,10 +837,10 @@ SavePartyLocation,unboarding,f,Boolean,0x68,False,0,0,
 SavePartyLocation,preboard_move_speed,f,Int32,0x69,4,0,0,Move speed before the party boarded the vehicle
 SavePartyLocation,menu_calling,f,Boolean,0x6C,False,0,0,Flag which briefly is true if the player presses ESC. At the right place in handling each frame's activities for the player; the code checks whether this flag is set and calls the menu; however there are several conditions which would cancel this flag and instead process another higher-priority action; such as when an encounter takes place during the same frame.
 SavePartyLocation,pan_state,f,Enum<SavePartyLoction_PanState>,0x6f,1,0,0,0: screen is fixed; 1: screen moves with player.
-SavePartyLocation,pan_current_x,f,Int32,0x70,2304,0,0,Number of 1/16 pixels to the left of player
-SavePartyLocation,pan_current_y,f,Int32,0x71,1792,0,0,Number of 1/16 pixels above the player
-SavePartyLocation,pan_finish_x,f,Int32,0x72,2304,0,0,Number of 1/16 pixels to the left of player when current scroll finishes
-SavePartyLocation,pan_finish_y,f,Int32,0x73,1792,0,0,Number of 1/16 pixels above the player when current scroll finishes.
+SavePartyLocation,pan_current_x,f,Int32,0x70,kPanXDefault,0,0,Number of 1/16 pixels to the left of player
+SavePartyLocation,pan_current_y,f,Int32,0x71,kPanYDefault,0,0,Number of 1/16 pixels above the player
+SavePartyLocation,pan_finish_x,f,Int32,0x72,kPanXDefault,0,0,Number of 1/16 pixels to the left of player when current scroll finishes
+SavePartyLocation,pan_finish_y,f,Int32,0x73,kPanYDefault,0,0,Number of 1/16 pixels above the player when current scroll finishes.
 SavePartyLocation,pan_speed,f,Int32,0x79,16,0,0,speed in the scrolls of the screen - shown in sixteenth pixels.
 SavePartyLocation,encounter_steps,f,Int32,0x7C,0,0,0,int: sum of terrain.encounter_rate for each step
 SavePartyLocation,encounter_calling,f,Boolean,0x7D,False,0,0,Similar to 0x6C - is used to signal a different piece of code that an encounter is to be triggered; which may be cancelled by other conditions such as the player starting to interact with an event during the same frame.

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -339,7 +339,7 @@ def generate():
                         type=filetype
                     ))
 
-                if needs_ctor(struct.name):
+                if needs_ctor(struct.name) or struct.name in constants:
                     filepath = os.path.join(tmp_dir, 'rpg_%s.cpp' % filename)
                     with open(filepath, 'w') as f:
                         f.write(rpg_source_tmpl.render(

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -273,6 +273,9 @@ def get_flags(filename='flags.csv'):
 def get_setup(filename='setup.csv'):
     return process_file(filename, namedtuple("Setup", "method headers"))
 
+def get_constants(filename='constants.csv'):
+    return process_file(filename, namedtuple("Constant", "name type value comment"))
+
 def get_headers():
     header_map = dict()
 
@@ -379,7 +382,7 @@ def main(argv):
     if not os.path.exists(dest_dir):
         os.mkdir(dest_dir)
 
-    global structs, sfields, enums, flags, setup, headers
+    global structs, sfields, enums, flags, setup, constants, headers
     global chunk_tmpl, lcf_struct_tmpl, rpg_header_tmpl, rpg_source_tmpl, flags_tmpl, enums_tmpl
 
     structs = get_structs()
@@ -387,6 +390,7 @@ def main(argv):
     enums = get_enums()
     flags = get_flags()
     setup = get_setup()
+    constants = get_constants()
     headers = get_headers()
 
     # Setup Jinja
@@ -407,6 +411,7 @@ def main(argv):
         flags=flags,
         enums=enums,
         setup=setup,
+        constants=constants,
         headers=headers
     )
 

--- a/generator/templates/rpg_header.tmpl
+++ b/generator/templates/rpg_header.tmpl
@@ -25,6 +25,12 @@ namespace RPG {
 	{%- if struct_name == "Map" %}
 		std::string lmu_header;
 	{%- endif %}
+	{%- if struct_name in constants %}
+	{%- for name, type, value, comment in constants[struct_name] %}
+		// {{ comment }}
+		static constexpr {{ type }} {{ name }} = {{ value }};
+	{%- endfor %}
+	{% endif %}
 	{%- if struct_name in enums %}
 	{%- for name, enum in enums[struct_name].items() %}
 		{%- if name == "Code" %}

--- a/generator/templates/rpg_source.tmpl
+++ b/generator/templates/rpg_source.tmpl
@@ -1,10 +1,16 @@
 {% include "copyright.tmpl" %}
 // Headers
 #include "rpg_{{ filename }}.h"
-
+{% if struct_name in constants -%}
+{%- for name, type, value, comment in constants[struct_name] %}
+constexpr {{ type }} RPG::{{ struct_name }}::{{ name }};
+{%- endfor %}
+{%- endif %}
+{% if struct_name is needs_ctor -%}
 /**
  * Constructor.
  */
 RPG::{{ struct_name }}::{{ struct_name }}() {
 	Init();
 }
+{%- endif %}

--- a/src/generated/rpg_savepartylocation.cpp
+++ b/src/generated/rpg_savepartylocation.cpp
@@ -1,0 +1,17 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2018 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+// Headers
+#include "rpg_savepartylocation.h"
+
+constexpr int RPG::SavePartyLocation::kPanXDefault;
+constexpr int RPG::SavePartyLocation::kPanYDefault;
+

--- a/src/generated/rpg_savepartylocation.h
+++ b/src/generated/rpg_savepartylocation.h
@@ -23,6 +23,11 @@
 namespace RPG {
 	class SavePartyLocation : public SaveMapEventBase {
 	public:
+		// Equal to 9 tiles in 1/16th pixels
+		static constexpr int kPanXDefault = 9 * 256;
+		// Equal to 7 tiles in 1/16th pixels
+		static constexpr int kPanYDefault = 7 * 256;
+
 		enum VehicleType {
 			VehicleType_none = 0,
 			VehicleType_skiff = 1,
@@ -51,10 +56,10 @@ namespace RPG {
 		int32_t preboard_move_speed = 4;
 		bool menu_calling = false;
 		int32_t pan_state = 1;
-		int32_t pan_current_x = 2304;
-		int32_t pan_current_y = 1792;
-		int32_t pan_finish_x = 2304;
-		int32_t pan_finish_y = 1792;
+		int32_t pan_current_x = kPanXDefault;
+		int32_t pan_current_y = kPanYDefault;
+		int32_t pan_finish_x = kPanXDefault;
+		int32_t pan_finish_y = kPanYDefault;
 		int32_t pan_speed = 16;
 		int32_t encounter_steps = 0;
 		bool encounter_calling = false;

--- a/src/generated/rpg_state.cpp
+++ b/src/generated/rpg_state.cpp
@@ -1,0 +1,16 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2018 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+// Headers
+#include "rpg_state.h"
+
+constexpr int RPG::State::kDeathID;
+

--- a/src/generated/rpg_state.h
+++ b/src/generated/rpg_state.h
@@ -23,6 +23,9 @@
 namespace RPG {
 	class State {
 	public:
+		// The ID of the special death state
+		static constexpr int kDeathID = 1;
+
 		enum Persistence {
 			Persistence_ends = 0,
 			Persistence_persists = 1


### PR DESCRIPTION
Towards fixing https://github.com/EasyRPG/Player/issues/1516

Also adds panning constants, so that the default pan values don't need to be duplicated between player and liblcf.