### PR TITLE
Composite Characters Fix

### DIFF
--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -13,8 +13,8 @@
 #ifdef LCF_SUPPORT_ICU
 #   include <unicode/ucsdet.h>
 #   include <unicode/ucnv.h>
-#	include <unicode/normalizer2.h>
-#	include <unicode/unistr.h>
+#   include <unicode/normalizer2.h>
+#   include <unicode/unistr.h>
 #else
 #   ifdef _MSC_VER
 #		error MSVC builds require ICU
@@ -387,7 +387,6 @@ std::string ReaderUtil::Normalize(const std::string &str) {
 	f.toUTF8String(res);
 	return res;
 #else
-	// LAME
 	std::string result = str;
 	std::transform(result.begin(), result.end(), result.begin(), tolower);
 	return result;

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -379,12 +379,16 @@ std::string ReaderUtil::Recode(const std::string& str_to_encode,
 
 std::string ReaderUtil::Normalize(const std::string &str) {
 #ifdef LCF_SUPPORT_ICU
-	icu::UnicodeString& uni = icu::UnicodeString(str.c_str()).toLower();
+	icu::UnicodeString uni = icu::UnicodeString(str.c_str()).toLower();
 	UErrorCode err = U_ZERO_ERROR;
+	std::string res;
 	const icu::Normalizer2* norm = icu::Normalizer2::getNFKCInstance(err);
 	icu::UnicodeString f = norm->normalize(uni, err);
-	std::string res;
-	f.toUTF8String(res);
+	if (U_FAILURE(err)) {
+		uni.toUTF8String(res);
+	} else {
+		f.toUTF8String(res);
+	}
 	return res;
 #else
 	std::string result = str;

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -13,6 +13,8 @@
 #ifdef LCF_SUPPORT_ICU
 #   include <unicode/ucsdet.h>
 #   include <unicode/ucnv.h>
+#	include <unicode/normalizer2.h>
+#	include <unicode/unistr.h>
 #else
 #   ifdef _MSC_VER
 #		error MSVC builds require ICU
@@ -371,6 +373,23 @@ std::string ReaderUtil::Recode(const std::string& str_to_encode,
 	*q++ = '\0';
 	std::string result(dst);
 	delete[] dst;
+	return result;
+#endif
+}
+
+std::string ReaderUtil::Normalize(const std::string &str) {
+#ifdef LCF_SUPPORT_ICU
+	icu::UnicodeString& uni = icu::UnicodeString(str.c_str()).toLower();
+	UErrorCode err = U_ZERO_ERROR;
+	const icu::Normalizer2* norm = icu::Normalizer2::getNFKCInstance(err);
+	icu::UnicodeString f = norm->normalize(uni, err);
+	std::string res;
+	f.toUTF8String(res);
+	return res;
+#else
+	// LAME
+	std::string result = str;
+	std::transform(result.begin(), result.end(), result.begin(), tolower);
 	return result;
 #endif
 }

--- a/src/reader_util.h
+++ b/src/reader_util.h
@@ -111,6 +111,15 @@ namespace ReaderUtil {
 					   const std::string& dst_enc);
 
 	/**
+	 * Converts a UTF-8 string to lowercase and then decomposes it.
+	 * 
+	 * @param str the string to normalize.
+	 * @return the normalized string.
+	 */
+	std::string Normalize(const std::string &str);
+
+
+	/**
 	 * Helper function that returns an element from a vector using a 1-based
 	 * index as usually used by LCF data structures.
 	 *


### PR DESCRIPTION
[#1530](https://github.com/EasyRPG/Player/issues/1530) and probably [#1383](https://github.com/EasyRPG/Player/issues/1383) and [#839](https://github.com/EasyRPG/Player/issues/839) in Player, by implementing normalization in place of lower-casing per @Ghabry's patch in [#839](https://github.com/EasyRPG/Player/issues/839).

Requires more thorough testing, but is confirmed to work against the Yume2kki example in [#1530](https://github.com/EasyRPG/Player/issues/1530).

***
Also needs to be tested that it doesn't break everything on [non-Mac platforms which use NFC as opposed to NFD](https://gist.github.com/JamesChevalier/8448512).