### PR TITLE
Create icu::UnicodeString with UTF-8 codepage, fixes normalize on Windows

### DIFF
--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -375,7 +375,7 @@ std::string ReaderUtil::Recode(const std::string& str_to_encode,
 
 std::string ReaderUtil::Normalize(const std::string &str) {
 #ifdef LCF_SUPPORT_ICU
-	icu::UnicodeString uni = icu::UnicodeString(str.c_str()).toLower();
+	icu::UnicodeString uni = icu::UnicodeString(str.c_str(), "utf-8").toLower();
 	UErrorCode err = U_ZERO_ERROR;
 	std::string res;
 	const icu::Normalizer2* norm = icu::Normalizer2::getNFKCInstance(err);


### PR DESCRIPTION
This amends #292 , works now properly on Windows