### PR TITLE
Fix compilation error when LCF_SUPPORT_ICU is not defined in reader_util.cpp

### DIFF
--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -33,7 +33,7 @@
 #if defined(__MORPHOS__) || defined(__amigaos4__)
 #define ICONV_CONST const
 #endif
-
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <sstream>


### PR DESCRIPTION
When LCF_SUPPORT_ICU is not defined during compilation (ICU support is disabled),
there's a compilation error due to the fact that std::transform is only referenced in algorithm.