### PR TITLE
Fix MapEvent  waiting and trigger chunks

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -979,7 +979,7 @@ SaveMapEventBase,flash_current_level,f,Double,0x54,0.0,0,0,double
 SaveMapEventBase,flash_time_left,f,Int32,0x55,0,0,0,int
 SaveMapEvent,waiting_execution,f,Boolean,0x65,False,0,0,If true; this event is waiting for foreground execution.
 SaveMapEvent,original_move_route_index,f,Int32,0x66,0,0,0,Index of custom move route
-SaveMapEvent,pending,f,Boolean,0x67,False,0,0,If true; this event will run after the current running event stops running. FIXME: See issue #174
+SaveMapEvent,triggered_by_decision_key,f,Boolean,0x67,False,0,0,If true; this event was started by the decision key.
 SaveMapEvent,event_data,f,SaveEventData,0x6C,,1,0,chunks
 SaveMapInfo,position_x,f,Int32,0x01,0,0,0,int
 SaveMapInfo,position_y,f,Int32,0x02,0,0,0,int

--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -977,7 +977,7 @@ SaveMapEventBase,flash_green,f,Int32,0x52,100,0,0,int
 SaveMapEventBase,flash_blue,f,Int32,0x53,100,0,0,int
 SaveMapEventBase,flash_current_level,f,Double,0x54,0.0,0,0,double
 SaveMapEventBase,flash_time_left,f,Int32,0x55,0,0,0,int
-SaveMapEvent,running,f,Boolean,0x65,False,0,0,?
+SaveMapEvent,waiting_execution,f,Boolean,0x65,False,0,0,If true; this event is waiting for foreground execution.
 SaveMapEvent,original_move_route_index,f,Int32,0x66,0,0,0,Index of custom move route
 SaveMapEvent,pending,f,Boolean,0x67,False,0,0,If true; this event will run after the current running event stops running. FIXME: See issue #174
 SaveMapEvent,event_data,f,SaveEventData,0x6C,,1,0,chunks

--- a/src/generated/lsd_chunks.h
+++ b/src/generated/lsd_chunks.h
@@ -868,8 +868,8 @@ namespace LSD_Reader {
 			flash_current_level = 0x54,
 			/** int */
 			flash_time_left = 0x55,
-			/** ? */
-			running = 0x65,
+			/** If true; this event is waiting for foreground execution. */
+			waiting_execution = 0x65,
 			/** Index of custom move route */
 			original_move_route_index = 0x66,
 			/** If true; this event will run after the current running event stops running. FIXME: See issue #174 */

--- a/src/generated/lsd_chunks.h
+++ b/src/generated/lsd_chunks.h
@@ -872,8 +872,8 @@ namespace LSD_Reader {
 			waiting_execution = 0x65,
 			/** Index of custom move route */
 			original_move_route_index = 0x66,
-			/** If true; this event will run after the current running event stops running. FIXME: See issue #174 */
-			pending = 0x67,
+			/** If true; this event was started by the decision key. */
+			triggered_by_decision_key = 0x67,
 			/** chunks */
 			event_data = 0x6C
 		};

--- a/src/generated/lsd_savemapevent.cpp
+++ b/src/generated/lsd_savemapevent.cpp
@@ -295,9 +295,9 @@ Field<RPG::SaveMapEvent> const* Struct<RPG::SaveMapEvent>::fields[] = {
 		0
 	),
 	new TypedField<RPG::SaveMapEvent, bool>(
-		&RPG::SaveMapEvent::running,
-		LSD_Reader::ChunkSaveMapEvent::running,
-		"running",
+		&RPG::SaveMapEvent::waiting_execution,
+		LSD_Reader::ChunkSaveMapEvent::waiting_execution,
+		"waiting_execution",
 		0,
 		0
 	),

--- a/src/generated/lsd_savemapevent.cpp
+++ b/src/generated/lsd_savemapevent.cpp
@@ -309,9 +309,9 @@ Field<RPG::SaveMapEvent> const* Struct<RPG::SaveMapEvent>::fields[] = {
 		0
 	),
 	new TypedField<RPG::SaveMapEvent, bool>(
-		&RPG::SaveMapEvent::pending,
-		LSD_Reader::ChunkSaveMapEvent::pending,
-		"pending",
+		&RPG::SaveMapEvent::triggered_by_decision_key,
+		LSD_Reader::ChunkSaveMapEvent::triggered_by_decision_key,
+		"triggered_by_decision_key",
 		0,
 		0
 	),

--- a/src/generated/rpg_savemapevent.h
+++ b/src/generated/rpg_savemapevent.h
@@ -28,14 +28,14 @@ namespace RPG {
 		int ID = 0;
 		bool waiting_execution = false;
 		int32_t original_move_route_index = 0;
-		bool pending = false;
+		bool triggered_by_decision_key = false;
 		SaveEventData event_data;
 	};
 
 	inline bool operator==(const SaveMapEvent& l, const SaveMapEvent& r) {
 		return l.waiting_execution == r.waiting_execution
 		&& l.original_move_route_index == r.original_move_route_index
-		&& l.pending == r.pending
+		&& l.triggered_by_decision_key == r.triggered_by_decision_key
 		&& l.event_data == r.event_data;
 	}
 

--- a/src/generated/rpg_savemapevent.h
+++ b/src/generated/rpg_savemapevent.h
@@ -26,14 +26,14 @@ namespace RPG {
 	public:
 		void Setup(const RPG::Event& event);
 		int ID = 0;
-		bool running = false;
+		bool waiting_execution = false;
 		int32_t original_move_route_index = 0;
 		bool pending = false;
 		SaveEventData event_data;
 	};
 
 	inline bool operator==(const SaveMapEvent& l, const SaveMapEvent& r) {
-		return l.running == r.running
+		return l.waiting_execution == r.waiting_execution
 		&& l.original_move_route_index == r.original_move_route_index
 		&& l.pending == r.pending
 		&& l.event_data == r.event_data;


### PR DESCRIPTION
This is the flag used to say an event is waiting for
foreground execution.

As described by Cherry in https://github.com/EasyRPG/Player/issues/1247

For `waiting_execution` chunk, simply create 2 autostart events with
```
OpenSaveMenu
```

The second event will have the flag set, while the first one (currently executing) does not.

For the `trigger_by_decision_key` chunk. Change the above events to trigger type `action`, `touch`, and/or `collision` and talk to them with the decision key. The chunk will be set in the save data.