### PR TITLE
Savegame move speed default is 4 and not 3

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -952,7 +952,7 @@ SaveMapEventBase,layer,f,Int32,0x21,1,1,0,?
 SaveMapEventBase,overlap_forbidden,f,Boolean,0x22,False,0,0,Flag
 SaveMapEventBase,animation_type,f,Enum<EventPage_AnimType>,0x23,0,1,0,
 SaveMapEventBase,lock_facing,f,Boolean,0x24,False,0,0,facing locked
-SaveMapEventBase,move_speed,f,Int32,0x25,3,1,0,
+SaveMapEventBase,move_speed,f,Int32,0x25,4,1,0,
 SaveMapEventBase,move_route,f,MoveRoute,0x29,,1,0,chunks: RPG::MoveRoute
 SaveMapEventBase,move_route_overwrite,f,Boolean,0x2A,False,0,0,Use custom move route
 SaveMapEventBase,move_route_index,f,Int32,0x2B,0,0,0,Index of MoveEvent command route

--- a/src/generated/rpg_savemapeventbase.h
+++ b/src/generated/rpg_savemapeventbase.h
@@ -38,7 +38,7 @@ namespace RPG {
 		bool overlap_forbidden = false;
 		int32_t animation_type = 0;
 		bool lock_facing = false;
-		int32_t move_speed = 3;
+		int32_t move_speed = 4;
 		MoveRoute move_route;
 		bool move_route_overwrite = false;
 		int32_t move_route_index = 0;


### PR DESCRIPTION
Fix EasyRPG/Player#1650

The only way to trigger this is by manually killing the chunk in a hex editor or by saving with Player 0.5.4 which omits the chunk and assumes 4 as default (the chunk is persitent, even when defaulted). Now the hero has normal speed after loading an old save.
Guess this was changed by accident during refactor because the Move speed in the LDB has 3 as default... Not very consistent.