### PR TITLE
Add Easyrpg savegame chunk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,11 @@ add_library(lcf
 	src/encoder.cpp
 	src/encoder.h
 	src/enum_tags.h
+	src/flag_set.h
 	src/ini.cpp
 	src/ini.h
 	src/inireader.cpp
 	src/inireader.h
-	src/flag_set.h
 	src/lcf_options.h
 	src/lcf_saveopt.h
 	src/ldb_equipment.cpp
@@ -126,6 +126,7 @@ add_library(lcf
 	src/generated/lsd_save.cpp
 	src/generated/lsd_saveactor.cpp
 	src/generated/lsd_savecommonevent.cpp
+	src/generated/lsd_saveeasyrpgdata.cpp
 	src/generated/lsd_saveeventcommands.cpp
 	src/generated/lsd_saveeventdata.cpp
 	src/generated/lsd_saveinventory.cpp
@@ -179,6 +180,7 @@ add_library(lcf
 	src/generated/rpg_save.h
 	src/generated/rpg_saveactor.h
 	src/generated/rpg_savecommonevent.h
+	src/generated/rpg_saveeasyrpgdata.h
 	src/generated/rpg_saveeventcommands.h
 	src/generated/rpg_saveeventdata.h
 	src/generated/rpg_saveinventory.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -99,6 +99,7 @@ liblcf_la_SOURCES = \
 	src/generated/lsd_save.cpp \
 	src/generated/lsd_saveactor.cpp \
 	src/generated/lsd_savecommonevent.cpp \
+	src/generated/lsd_saveeasyrpgdata.cpp \
 	src/generated/lsd_saveeventcommands.cpp \
 	src/generated/lsd_saveeventdata.cpp \
 	src/generated/lsd_saveinventory.cpp \
@@ -184,6 +185,7 @@ pkginclude_HEADERS = \
 	src/generated/rpg_save.h \
 	src/generated/rpg_saveactor.h \
 	src/generated/rpg_savecommonevent.h \
+	src/generated/rpg_saveeasyrpgdata.h \
 	src/generated/rpg_saveeventcommands.h \
 	src/generated/rpg_saveeventdata.h \
 	src/generated/rpg_saveinventory.h \

--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -1,0 +1,3 @@
+#Structure,Field,Size Field?,Type,Index,Default Value,PersistIfDefault,Is2k3,Comment
+Save,easyrpg_data,f,SaveEasyRpgData,0xc8,,0,0,Additional save data written by EasyRPG Player
+SaveEasyRpgData,version,,Int32,1,0,0,0,Savegame version

--- a/generator/csv/structs_easyrpg.csv
+++ b/generator/csv/structs_easyrpg.csv
@@ -1,0 +1,2 @@
+#Type,Structure,Base,Index available?
+lsd,SaveEasyRpgData,,0

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -410,8 +410,8 @@ def main(argv):
     global structs, sfields, enums, flags, setup, constants, headers
     global chunk_tmpl, lcf_struct_tmpl, rpg_header_tmpl, rpg_source_tmpl, flags_tmpl, enums_tmpl
 
-    structs = get_structs('structs.csv')
-    sfields = get_fields('fields.csv')
+    structs = get_structs('structs.csv','structs_easyrpg.csv')
+    sfields = get_fields('fields.csv','fields_easyrpg.csv')
     enums = get_enums('enums.csv')
     flags = get_flags('flags.csv')
     setup = get_setup('setup.csv')

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -195,6 +195,22 @@ def struct_headers(ty, header_map):
 
     return []
 
+def merge_dicts(dicts):
+    # Merges multiple dicts into one
+    out_dict = dicts[0]
+
+    for d in dicts[1:]:
+        for k,v in d.items():
+            if k in out_dict:
+                # Append new values
+                for vv in v:
+                    out_dict[k].append(vv)
+            else:
+                # Insert whole key
+                out_dict[k] = v
+
+    return out_dict
+
 def process_file(filename, namedtup):
     # Mapping is: All elements of the line grouped by the first column
 
@@ -215,14 +231,14 @@ def process_file(filename, namedtup):
 
     return result
 
-def get_structs(filename='structs.csv'):
+def get_structs(*filenames):
     Struct = namedtuple("Struct", "name base hasid")
 
-    result = process_file(filename, Struct)
+    results = list(map(lambda x: process_file(x, Struct), filenames))
 
     processed_result = OrderedDict()
 
-    for k, struct in result.items():
+    for k, struct in merge_dicts(results).items():
         processed_result[k] = []
 
         for elem in struct:
@@ -231,14 +247,14 @@ def get_structs(filename='structs.csv'):
 
     return processed_result
 
-def get_fields(filename='fields.csv'):
+def get_fields(*filenames):
     Field = namedtuple("Field", "name size type code default presentifdefault is2k3 comment")
 
-    result = process_file(filename, Field)
+    results = list(map(lambda x: process_file(x, Field), filenames))
 
     processed_result = OrderedDict()
 
-    for k, field in result.items():
+    for k, field in merge_dicts(results).items():
         processed_result[k] = []
         for elem in field:
             elem = Field(
@@ -254,24 +270,26 @@ def get_fields(filename='fields.csv'):
 
     return processed_result
 
-def get_enums(filename='enums.csv'):
-    result = process_file(filename, namedtuple("Enum", "entry value index"))
+def get_enums(*filenames):
+    results = list(map(lambda x: process_file(x, namedtuple("Enum", "entry value index")), filenames))
     new_result = OrderedDict()
 
     # Additional processing to group by the Enum Entry
     # Results in e.g. EventCommand -> Code -> List of (Name, Index)
-    for k, v in result.items():
+    for k, v in merge_dicts(results).items():
         new_result[k] = OrderedDict()
         for kk, gg in groupby(v, operator.attrgetter("entry")):
             new_result[k][kk] = list(map(lambda x: (x.value, x.index), gg))
 
     return new_result
 
-def get_flags(filename='flags.csv'):
-    return process_file(filename, namedtuple("Flag", "field is2k3"))
+def get_flags(*filenames):
+    results = list(map(lambda x: process_file(x, namedtuple("Flag", "field is2k3")), filenames))
+    return merge_dicts(results)
 
-def get_setup(filename='setup.csv'):
-    return process_file(filename, namedtuple("Setup", "method headers"))
+def get_setup(*filenames):
+    results = list(map(lambda x: process_file(x, namedtuple("Setup", "method headers")), filenames))
+    return merge_dicts(results)
 
 def get_constants(filename='constants.csv'):
     return process_file(filename, namedtuple("Constant", "name type value comment"))
@@ -392,11 +410,11 @@ def main(argv):
     global structs, sfields, enums, flags, setup, constants, headers
     global chunk_tmpl, lcf_struct_tmpl, rpg_header_tmpl, rpg_source_tmpl, flags_tmpl, enums_tmpl
 
-    structs = get_structs()
-    sfields = get_fields()
-    enums = get_enums()
-    flags = get_flags()
-    setup = get_setup()
+    structs = get_structs('structs.csv')
+    sfields = get_fields('fields.csv')
+    enums = get_enums('enums.csv')
+    flags = get_flags('flags.csv')
+    setup = get_setup('setup.csv')
     constants = get_constants()
     headers = get_headers()
 

--- a/src/generated/lsd_chunks.h
+++ b/src/generated/lsd_chunks.h
@@ -955,7 +955,15 @@ namespace LSD_Reader {
 			/** RPG::SaveEventData */
 			events = 0x71,
 			/** array of RPG::SaveCommonEvent */
-			common_events = 0x72
+			common_events = 0x72,
+			/** Additional save data written by EasyRPG Player */
+			easyrpg_data = 0xC8
+		};
+	};
+	struct ChunkSaveEasyRpgData {
+		enum Index {
+			/** Savegame version */
+			version = 0x01
 		};
 	};
 }

--- a/src/generated/lsd_save.cpp
+++ b/src/generated/lsd_save.cpp
@@ -126,6 +126,13 @@ Field<RPG::Save> const* Struct<RPG::Save>::fields[] = {
 		1,
 		0
 	),
+	new TypedField<RPG::Save, RPG::SaveEasyRpgData>(
+		&RPG::Save::easyrpg_data,
+		LSD_Reader::ChunkSave::easyrpg_data,
+		"easyrpg_data",
+		0,
+		0
+	),
 	NULL
 };
 

--- a/src/generated/lsd_saveeasyrpgdata.cpp
+++ b/src/generated/lsd_saveeasyrpgdata.cpp
@@ -1,0 +1,34 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2018 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+// Headers
+#include "lsd_reader.h"
+#include "lsd_chunks.h"
+#include "reader_struct_impl.h"
+
+// Read SaveEasyRpgData.
+
+template <>
+char const* const Struct<RPG::SaveEasyRpgData>::name = "SaveEasyRpgData";
+
+template <>
+Field<RPG::SaveEasyRpgData> const* Struct<RPG::SaveEasyRpgData>::fields[] = {
+	new TypedField<RPG::SaveEasyRpgData, int32_t>(
+		&RPG::SaveEasyRpgData::version,
+		LSD_Reader::ChunkSaveEasyRpgData::version,
+		"version",
+		0,
+		0
+	),
+	NULL
+};
+
+template class Struct<RPG::SaveEasyRpgData>;

--- a/src/generated/rpg_save.h
+++ b/src/generated/rpg_save.h
@@ -16,6 +16,7 @@
 #include <vector>
 #include "rpg_saveactor.h"
 #include "rpg_savecommonevent.h"
+#include "rpg_saveeasyrpgdata.h"
 #include "rpg_saveeventdata.h"
 #include "rpg_saveinventory.h"
 #include "rpg_savemapinfo.h"
@@ -50,6 +51,7 @@ namespace RPG {
 		SavePanorama panorama;
 		SaveEventData events;
 		std::vector<SaveCommonEvent> common_events;
+		SaveEasyRpgData easyrpg_data;
 	};
 
 	inline bool operator==(const Save& l, const Save& r) {
@@ -67,7 +69,8 @@ namespace RPG {
 		&& l.map_info == r.map_info
 		&& l.panorama == r.panorama
 		&& l.events == r.events
-		&& l.common_events == r.common_events;
+		&& l.common_events == r.common_events
+		&& l.easyrpg_data == r.easyrpg_data;
 	}
 
 	inline bool operator!=(const Save& l, const Save& r) {

--- a/src/generated/rpg_saveeasyrpgdata.h
+++ b/src/generated/rpg_saveeasyrpgdata.h
@@ -1,0 +1,36 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2018 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+#ifndef LCF_RPG_SAVEEASYRPGDATA_H
+#define LCF_RPG_SAVEEASYRPGDATA_H
+
+// Headers
+#include "enum_tags.h"
+
+/**
+ * RPG::SaveEasyRpgData class.
+ */
+namespace RPG {
+	class SaveEasyRpgData {
+	public:
+		int32_t version = 0;
+	};
+
+	inline bool operator==(const SaveEasyRpgData& l, const SaveEasyRpgData& r) {
+		return l.version == r.version;
+	}
+
+	inline bool operator!=(const SaveEasyRpgData& l, const SaveEasyRpgData& r) {
+		return !(l == r);
+	}
+}
+
+#endif

--- a/src/lsd_reader.cpp
+++ b/src/lsd_reader.cpp
@@ -32,11 +32,11 @@ double LSD_Reader::GenerateTimestamp(std::time_t const t) {
 	return ToTDateTime(t);
 }
 
-void LSD_Reader::PrepareSave(RPG::Save& save) {
+void LSD_Reader::PrepareSave(RPG::Save& save, int32_t version) {
 	++save.system.save_count;
 	save.title.timestamp = LSD_Reader::GenerateTimestamp();
+	save.easyrpg_data.version = version;
 }
-
 
 std::unique_ptr<RPG::Save> LSD_Reader::Load(const std::string& filename, const std::string& encoding) {
 	std::ifstream stream(filename.c_str(), std::ios::binary);

--- a/src/lsd_reader.h
+++ b/src/lsd_reader.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <memory>
 #include <ctime>
+#include <stdint.h>
 #include "rpg_save.h"
 
 /**
@@ -24,7 +25,6 @@ namespace LSD_Reader {
 	 * Converts from UNIX timestamp to Delphi's TDateTime format.
 	 */
 	double ToTDateTime(std::time_t const t);
-
 
 	/**
 	 * Converts from Delphi's TDateTime format to UNIX timestamp.
@@ -39,7 +39,7 @@ namespace LSD_Reader {
 	/**
 	 * Increment the save save_count and update the timestamp.
 	 */
-	void PrepareSave(RPG::Save& save);
+	void PrepareSave(RPG::Save& save, int32_t version = 0);
 
 	/**
 	 * Returns a copy of the save data with defaults cleared.


### PR DESCRIPTION
This adds a new EasyRpg chunk to the savegame with one field: version.

I picked 0xc8 (200) because Cherry asked us to look at the decimals and RPG_RT starts at 0x64 (100)

Patch for the Player site, wrapping our compatibility hack in a if-block.

```
diff --git a/src/player.cpp b/src/player.cpp
index 64e3ea35..e833188a 100644
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -812,11 +812,12 @@ static void OnMapSaveFileReady(FileRequestResult*) {
 	// Compatibility hack for pre 0.6 EasyRPG Player saves.
 	// Old savegames accidentally wrote animation_type as
 	// continuous for all events.
-	Main_Data::game_player->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
-	Game_Map::GetVehicle(Game_Vehicle::Boat)->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
-	Game_Map::GetVehicle(Game_Vehicle::Ship)->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
-	Game_Map::GetVehicle(Game_Vehicle::Airship)->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
-
+	if (Main_Data::game_data.easyrpg_data.version == RPG::SaveEasyRpgData::EasyRpg_Version_legacy) {
+		Main_Data::game_player->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
+		Game_Map::GetVehicle(Game_Vehicle::Boat)->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
+		Game_Map::GetVehicle(Game_Vehicle::Ship)->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
+		Game_Map::GetVehicle(Game_Vehicle::Airship)->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
+	}
 	Main_Data::game_player->Refresh();
 
 	RPG::Music current_music = Main_Data::game_data.system.current_music;
```