### PR TITLE
MorphOS build fix

### DIFF
--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -2,6 +2,7 @@
 #include "encoder.h"
 #include "reader_util.h"
 #include "scope_guard.h"
+#include <cstdlib>
 #include <exception>
 
 #ifdef LCF_SUPPORT_ICU


### PR DESCRIPTION
On other platforms stdlib.h gets included by other headers, but not on MorphOS, where atoi doesn't get declared, so I added an explicit include in encoder.cpp.