### PR TITLE
Add missing <cstdio> include

### DIFF
--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -2,6 +2,7 @@
 #include "encoder.h"
 #include "reader_util.h"
 #include "scope_guard.h"
+#include <cstdio>
 #include <cstdlib>
 #include <exception>
 


### PR DESCRIPTION
This change, alongside ccawley2011/liblcf@9b2b46f, are needed when building liblcf on RISC OS.