### PR TITLE
Remove SaveVehicleLocation::original_move_route_index

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -847,7 +847,6 @@ SavePartyLocation,encounter_calling,f,Boolean,0x7D,False,0,0,Similar to 0x6C - i
 SavePartyLocation,map_save_count,f,Int32,0x83,0,0,0,Mirrors save_count of current map. On mismatch events are not continued after load.
 SavePartyLocation,database_save_count,f,Int32,0x84,0,0,0,?
 SaveVehicleLocation,vehicle,f,Enum<SaveVehicleLocation_VehicleType>,0x65,0,0,0,Which vehicle
-SaveVehicleLocation,original_move_route_index,f,Int32,0x66,0,0,0,Index of custom move route
 SaveVehicleLocation,remaining_ascent,f,Int32,0x6A,0,0,0,From 0 to 255 - In flying vehicles; remaining distance to ascend
 SaveVehicleLocation,remaining_descent,f,Int32,0x6B,0,0,0,From 0 to 255 - In flying vehicles; remaining distance to descend
 SaveVehicleLocation,sprite2_name,f,String,0x6F,'',0,0,string

--- a/src/generated/lsd_chunks.h
+++ b/src/generated/lsd_chunks.h
@@ -502,8 +502,6 @@ namespace LSD_Reader {
 			flash_time_left = 0x55,
 			/** Which vehicle */
 			vehicle = 0x65,
-			/** Index of custom move route */
-			original_move_route_index = 0x66,
 			/** From 0 to 255 - In flying vehicles; remaining distance to ascend */
 			remaining_ascent = 0x6A,
 			/** From 0 to 255 - In flying vehicles; remaining distance to descend */

--- a/src/generated/lsd_savevehiclelocation.cpp
+++ b/src/generated/lsd_savevehiclelocation.cpp
@@ -302,13 +302,6 @@ Field<RPG::SaveVehicleLocation> const* Struct<RPG::SaveVehicleLocation>::fields[
 		0
 	),
 	new TypedField<RPG::SaveVehicleLocation, int32_t>(
-		&RPG::SaveVehicleLocation::original_move_route_index,
-		LSD_Reader::ChunkSaveVehicleLocation::original_move_route_index,
-		"original_move_route_index",
-		0,
-		0
-	),
-	new TypedField<RPG::SaveVehicleLocation, int32_t>(
 		&RPG::SaveVehicleLocation::remaining_ascent,
 		LSD_Reader::ChunkSaveVehicleLocation::remaining_ascent,
 		"remaining_ascent",

--- a/src/generated/rpg_savevehiclelocation.h
+++ b/src/generated/rpg_savevehiclelocation.h
@@ -38,7 +38,6 @@ namespace RPG {
 		);
 
 		int32_t vehicle = 0;
-		int32_t original_move_route_index = 0;
 		int32_t remaining_ascent = 0;
 		int32_t remaining_descent = 0;
 		std::string sprite2_name;
@@ -47,7 +46,6 @@ namespace RPG {
 
 	inline bool operator==(const SaveVehicleLocation& l, const SaveVehicleLocation& r) {
 		return l.vehicle == r.vehicle
-		&& l.original_move_route_index == r.original_move_route_index
 		&& l.remaining_ascent == r.remaining_ascent
 		&& l.remaining_descent == r.remaining_descent
 		&& l.sprite2_name == r.sprite2_name


### PR DESCRIPTION
This chunk must not exist, because vehicles don't have
original move routes like events do.

Fix: #304