### PR TITLE
Rename 2k3 Skill/Item state_effect -> reverse_state_effect

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -144,7 +144,7 @@ Skill,animation_id,f,Ref<Animation>,0x0E,1,0,0,Integer
 Skill,sound_effect,f,Sound,0x10,,1,0,RPG::Sound
 Skill,occasion_field,f,Boolean,0x12,True,0,0,Flag
 Skill,occasion_battle,f,Boolean,0x13,False,0,0,Flag
-Skill,state_effect,f,Boolean,0x14,False,0,1,Flag - RPG2003
+Skill,reverse_state_effect,f,Boolean,0x14,False,0,1,Flag - RPG2003
 Skill,physical_rate,f,Int32,0x15,0,0,0,Integer
 Skill,magical_rate,f,Int32,0x16,3,0,0,Integer
 Skill,variance,f,Int32,0x17,4,0,0,Integer
@@ -222,7 +222,7 @@ Item,state_set,f,Vector<Boolean>,0x40,,1,0,Array - Flag
 Item,attribute_set,t,Boolean,0x41,,0,0,Integer
 Item,attribute_set,f,Vector<Boolean>,0x42,,1,0,Array - Flag
 Item,state_chance,f,Int32,0x43,0,0,0,Integer
-Item,state_effect,f,Boolean,0x44,False,0,0,Flag
+Item,reverse_state_effect,f,Boolean,0x44,False,0,0,Flag
 Item,weapon_animation,f,Ref<Actor>,0x45,-1,0,1,Integer - RPG2003
 Item,animation_data,f,Array<ItemAnimation:Ref<Actor>>,0x46,,1,1,Array - RPG2003
 Item,use_skill,f,Boolean,0x47,False,0,1,Flag - RPG2003

--- a/src/generated/ldb_chunks.h
+++ b/src/generated/ldb_chunks.h
@@ -373,7 +373,7 @@ namespace LDB_Reader {
 			/** Flag */
 			occasion_battle = 0x13,
 			/** Flag - RPG2003 */
-			state_effect = 0x14,
+			reverse_state_effect = 0x14,
 			/** Integer */
 			physical_rate = 0x15,
 			/** Integer */
@@ -537,7 +537,7 @@ namespace LDB_Reader {
 			/** Integer */
 			state_chance = 0x43,
 			/** Flag */
-			state_effect = 0x44,
+			reverse_state_effect = 0x44,
 			/** Integer - RPG2003 */
 			weapon_animation = 0x45,
 			/** Array - RPG2003 */

--- a/src/generated/ldb_item.cpp
+++ b/src/generated/ldb_item.cpp
@@ -355,9 +355,9 @@ Field<RPG::Item> const* Struct<RPG::Item>::fields[] = {
 		0
 	),
 	new TypedField<RPG::Item, bool>(
-		&RPG::Item::state_effect,
-		LDB_Reader::ChunkItem::state_effect,
-		"state_effect",
+		&RPG::Item::reverse_state_effect,
+		LDB_Reader::ChunkItem::reverse_state_effect,
+		"reverse_state_effect",
 		0,
 		0
 	),

--- a/src/generated/ldb_skill.cpp
+++ b/src/generated/ldb_skill.cpp
@@ -127,9 +127,9 @@ Field<RPG::Skill> const* Struct<RPG::Skill>::fields[] = {
 		0
 	),
 	new TypedField<RPG::Skill, bool>(
-		&RPG::Skill::state_effect,
-		LDB_Reader::ChunkSkill::state_effect,
-		"state_effect",
+		&RPG::Skill::reverse_state_effect,
+		LDB_Reader::ChunkSkill::reverse_state_effect,
+		"reverse_state_effect",
 		0,
 		1
 	),

--- a/src/generated/rpg_item.h
+++ b/src/generated/rpg_item.h
@@ -118,7 +118,7 @@ namespace RPG {
 		std::vector<bool> state_set;
 		std::vector<bool> attribute_set;
 		int32_t state_chance = 0;
-		bool state_effect = false;
+		bool reverse_state_effect = false;
 		int32_t weapon_animation = -1;
 		std::vector<ItemAnimation> animation_data;
 		bool use_skill = false;
@@ -176,7 +176,7 @@ namespace RPG {
 		&& l.attribute_set == r.attribute_set
 		&& l.attribute_set == r.attribute_set
 		&& l.state_chance == r.state_chance
-		&& l.state_effect == r.state_effect
+		&& l.reverse_state_effect == r.reverse_state_effect
 		&& l.weapon_animation == r.weapon_animation
 		&& l.animation_data == r.animation_data
 		&& l.use_skill == r.use_skill

--- a/src/generated/rpg_skill.h
+++ b/src/generated/rpg_skill.h
@@ -79,7 +79,7 @@ namespace RPG {
 		Sound sound_effect;
 		bool occasion_field = true;
 		bool occasion_battle = false;
-		bool state_effect = false;
+		bool reverse_state_effect = false;
 		int32_t physical_rate = 0;
 		int32_t magical_rate = 3;
 		int32_t variance = 4;
@@ -116,7 +116,7 @@ namespace RPG {
 		&& l.sound_effect == r.sound_effect
 		&& l.occasion_field == r.occasion_field
 		&& l.occasion_battle == r.occasion_battle
-		&& l.state_effect == r.state_effect
+		&& l.reverse_state_effect == r.reverse_state_effect
 		&& l.physical_rate == r.physical_rate
 		&& l.magical_rate == r.magical_rate
 		&& l.variance == r.variance


### PR DESCRIPTION
The original name was not descriptive and is almost the same
as state_effects, which is the state array.