### PR TITLE
Fix SaveActor Flags

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -877,10 +877,10 @@ SaveActor,status,f,Vector<Int16>,0x52,,1,0,array of short
 SaveActor,changed_battle_commands,f,Boolean,0x53,False,0,0,bool
 SaveActor,class_id,f,Ref<Class>,0x5A,-1,0,0,int class-id
 SaveActor,row,f,Enum<SaveActor_RowType>,0x5B,0,0,1,RPG2003 Battle row
-SaveActor,two_weapon,f,Boolean,0x5C,False,0,0,bool
-SaveActor,lock_equipment,f,Boolean,0x5D,False,0,0,bool
-SaveActor,auto_battle,f,Boolean,0x5E,False,0,0,bool
-SaveActor,super_guard,f,Boolean,0x5F,False,0,0,bool
+SaveActor,two_weapon,f,Boolean,0x5C,False,0,1,bool
+SaveActor,lock_equipment,f,Boolean,0x5D,False,0,1,bool
+SaveActor,auto_battle,f,Boolean,0x5E,False,0,1,bool
+SaveActor,super_guard,f,Boolean,0x5F,False,0,1,bool
 SaveActor,battler_animation,f,Ref<BattlerAnimation>,0x60,0,0,1,Integer - RPG2003
 SaveInventory,party_size,f,Int32,0x01,-1,0,0,?
 SaveInventory,party,f,Vector<Int16>,0x02,,1,0,?

--- a/src/generated/lsd_saveactor.cpp
+++ b/src/generated/lsd_saveactor.cpp
@@ -207,28 +207,28 @@ Field<RPG::SaveActor> const* Struct<RPG::SaveActor>::fields[] = {
 		LSD_Reader::ChunkSaveActor::two_weapon,
 		"two_weapon",
 		0,
-		0
+		1
 	),
 	new TypedField<RPG::SaveActor, bool>(
 		&RPG::SaveActor::lock_equipment,
 		LSD_Reader::ChunkSaveActor::lock_equipment,
 		"lock_equipment",
 		0,
-		0
+		1
 	),
 	new TypedField<RPG::SaveActor, bool>(
 		&RPG::SaveActor::auto_battle,
 		LSD_Reader::ChunkSaveActor::auto_battle,
 		"auto_battle",
 		0,
-		0
+		1
 	),
 	new TypedField<RPG::SaveActor, bool>(
 		&RPG::SaveActor::super_guard,
 		LSD_Reader::ChunkSaveActor::super_guard,
 		"super_guard",
 		0,
-		0
+		1
 	),
 	new TypedField<RPG::SaveActor, int32_t>(
 		&RPG::SaveActor::battler_animation,


### PR DESCRIPTION
Fix: https://github.com/EasyRPG/Player/issues/1789


It's not entirely clear to me whether this logic belongs in liblcf or Player. It seems that the fact that we use the `SaveActor` struct directly in Player (vs copying the data out to another structure), and therefore needing this adjustment is an implementation detail of Player.

Thoughts?