### PR TITLE
Fix SystemGraphics save chunks

### DIFF
--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -708,8 +708,8 @@ SaveTitle,face4_id,f,Int32,0x1C,0,0,0,int: face id
 SaveSystem,scene,f,Enum<SaveSystem_Scene>,0x01,0,1,0,The current Scene for RPG_RT. Legacy field only used by RPG_RT and not by EasyRPG Player. Savegames always have a scene of 5 (filemenu).
 SaveSystem,frame_count,f,Int32,0x0B,0,0,0,
 SaveSystem,graphics_name,f,String,0x15,'',0,0,string
-SaveSystem,message_stretch,f,Int32,0x16,-1,0,0,Integer
-SaveSystem,font_id,f,Int32,0x17,0,0,0,Integer
+SaveSystem,message_stretch,f,Enum<System_Stretch>,0x16,0,0,0,Integer
+SaveSystem,font_id,f,Enum<System_Font>,0x17,0,0,0,Integer
 SaveSystem,switches,t,Count<Boolean>,0x1F,0,0,0,
 SaveSystem,switches,f,Vector<Boolean>,0x20,,1,0,
 SaveSystem,variables,t,Count<Int32>,0x21,0,0,0,

--- a/src/generated/rpg_savesystem.h
+++ b/src/generated/rpg_savesystem.h
@@ -63,7 +63,7 @@ namespace RPG {
 		int32_t scene = 0;
 		int32_t frame_count = 0;
 		std::string graphics_name;
-		int32_t message_stretch = -1;
+		int32_t message_stretch = 0;
 		int32_t font_id = 0;
 		std::vector<bool> switches;
 		std::vector<int32_t> variables;

--- a/src/rpg_fixup.cpp
+++ b/src/rpg_fixup.cpp
@@ -81,9 +81,6 @@ void RPG::SaveActor::UnFixup() {
 void RPG::SaveSystem::Fixup() {
 	const RPG::System& system = Data::system;
 
-	if (graphics_name.empty()) {
-		graphics_name = system.system_name;
-	}
 	switches.reserve(Data::switches.size());
 	variables.reserve(Data::variables.size());
 	if (battle_music.name.empty()) {
@@ -147,7 +144,6 @@ void RPG::SaveSystem::Fixup() {
 		item_se = system.item_se;
 	}
 
-	FixInt(message_stretch, system.message_stretch);
 	FixInt(transition_out, system.transition_out);
 	FixInt(transition_in, system.transition_in);
 	FixInt(battle_start_fadeout, system.battle_start_fadeout);
@@ -169,10 +165,6 @@ void RPG::SaveSystem::UnFixup() {
 		s = {};
 		s.name.clear();
 	};
-
-	if (graphics_name == system.system_name) {
-		graphics_name.clear();
-	}
 
 	if (battle_music == system.battle_music) {
 		reset_bgm(battle_music);
@@ -235,7 +227,6 @@ void RPG::SaveSystem::UnFixup() {
 		reset_se(item_se);
 	}
 
-	UnFixInt(message_stretch, system.message_stretch);
 	UnFixInt(transition_out, system.transition_out);
 	UnFixInt(transition_in, system.transition_in);
 	UnFixInt(battle_start_fadeout, system.battle_start_fadeout);

--- a/src/rpg_setup.cpp
+++ b/src/rpg_setup.cpp
@@ -91,7 +91,6 @@ void RPG::SaveMapInfo::Setup(const RPG::Map& map) {
 void RPG::SaveSystem::Setup() {
 	const RPG::System& system = Data::system;
 	frame_count = 0;
-	graphics_name = system.system_name;
 	face_name = "";
 	face_id = -1;
 	face_right = false;
@@ -128,8 +127,6 @@ void RPG::SaveSystem::Setup() {
 	battle_start_fadein = system.battle_start_fadein;
 	battle_end_fadeout = system.battle_end_fadeout;
 	battle_end_fadein = system.battle_end_fadein;
-	message_stretch = system.message_stretch;
-	font_id = system.font_id;
 	teleport_allowed = true;
 	escape_allowed = true;
 	save_allowed = true;


### PR DESCRIPTION
When graphics_name is empty, it means that graphics_name,
message_stretch, and font_id all fallback to the database values.

If graphics_name is non-empty, all 3 parameters values are taken
literally.

Depends on: https://github.com/EasyRPG/Player/pull/1842