### PR TITLE
pkgconfig: Fix support for absolute lib and include dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,21 +273,21 @@ endif()
 # .so version
 set_property(TARGET lcf PROPERTY SOVERSION 0)
 
+# installation
+include(GNUInstallDirs)
+
 # pkg-config file generation
 set(PACKAGE_TARNAME ${PROJECT_NAME})
 set(PACKAGE_VERSION ${PROJECT_VERSION})
 set(prefix "${CMAKE_INSTALL_PREFIX}")
 set(exec_prefix "\${prefix}")
-set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
-set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
+set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
 string(REPLACE ";" " " AX_PACKAGE_REQUIRES_PRIVATE "${LIBLCF_DEPS}")
 configure_file(builds/${PROJECT_NAME}.pc.in builds/${PROJECT_NAME}.pc @ONLY)
 
 # Cmake-config file generation
 configure_file(builds/${PROJECT_NAME}-config.cmake.in builds/${PROJECT_NAME}-config.cmake @ONLY)
-
-# installation
-include(GNUInstallDirs)
 
 install(
 	TARGETS lcf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,12 +277,21 @@ set_property(TARGET lcf PROPERTY SOVERSION 0)
 include(GNUInstallDirs)
 
 # pkg-config file generation
+set(LCF_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+if(IS_ABSOLUTE ${LCF_LIBDIR})
+	file(RELATIVE_PATH LCF_LIBDIR ${CMAKE_INSTALL_PREFIX} ${LCF_LIBDIR})
+endif()
+set(LCF_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
+if(IS_ABSOLUTE ${LCF_INCLUDEDIR})
+	file(RELATIVE_PATH LCF_INCLUDEDIR ${CMAKE_INSTALL_PREFIX} ${LCF_INCLUDEDIR})
+endif()
+
 set(PACKAGE_TARNAME ${PROJECT_NAME})
 set(PACKAGE_VERSION ${PROJECT_VERSION})
 set(prefix "${CMAKE_INSTALL_PREFIX}")
 set(exec_prefix "\${prefix}")
-set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
-set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(libdir "\${exec_prefix}/${LCF_LIBDIR}")
+set(includedir "\${prefix}/${LCF_INCLUDEDIR}")
 string(REPLACE ";" " " AX_PACKAGE_REQUIRES_PRIVATE "${LIBLCF_DEPS}")
 configure_file(builds/${PROJECT_NAME}.pc.in builds/${PROJECT_NAME}.pc @ONLY)
 


### PR DESCRIPTION
Using GNUInstallDirs to always have an absolute path regardless of the
user input: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

---

Fixes issue mentioned in https://github.com/EasyRPG/Player/issues/1753#issuecomment-527319815
`CMAKE_INSTALL_{LIB,INCLUDE}DIR` can be used both with a relative path (`lib64`, `include`) or absolute (`/usr/lib64`, `/usr/local/include`, etc.), and in the latter case the previous logic is broken.

One drawback of this change is that it no longer makes use expanding `${exec_prefix}`, but to be honest I've never seen any real-life use case for that in `.pc` files. There might be on other platforms than Linux/*BSD though.

---

Not directly related, but since you put liblcf headers in a `liblcf` folder, I would advise for using `#include <liblcf/data.h>` instead of `#include "data.h"` in easyrpg-player, to avoid including the wrong file by mistake. (And I would have understood the issue in https://github.com/EasyRPG/Player/issues/1753#issuecomment-527319815 without having to bother @fdelapena if `liblcf` was part of the include path.)