### PR TITLE
Fix clang template warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(lcf
 	src/writer_lcf.h
 	src/writer_xml.cpp
 	src/writer_xml.h
+	src/generated/fwd_struct_impl.h
 	src/generated/ldb_actor.cpp
 	src/generated/ldb_animation.cpp
 	src/generated/ldb_animationcelldata.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -141,6 +141,7 @@ pkginclude_HEADERS = \
 	src/scope_guard.h \
 	src/writer_lcf.h \
 	src/writer_xml.h \
+	src/generated/fwd_struct_impl.h \
 	src/generated/ldb_chunks.h \
 	src/generated/ldb_terrain_flags.h \
 	src/generated/ldb_trooppagecondition_flags.h \

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -354,6 +354,17 @@ def generate():
                 type=filetype
             ))
 
+    structs_flat = []
+    for filetype, struct in structs.items():
+        for elem in struct:
+            structs_flat.append(elem)
+
+    filepath = os.path.join(tmp_dir, 'fwd_struct_impl.h')
+    with open(filepath, 'w') as f:
+        f.write(fwd_tmpl.render(
+            structs=sorted([x.name for x in structs_flat])
+        ))
+
     for filetype, structlist in structs.items():
         for struct in structlist:
             filename = struct.name.lower()
@@ -413,7 +424,7 @@ def main(argv):
         os.mkdir(dest_dir)
 
     global structs, sfields, enums, flags, setup, constants, headers
-    global chunk_tmpl, lcf_struct_tmpl, rpg_header_tmpl, rpg_source_tmpl, flags_tmpl, enums_tmpl
+    global chunk_tmpl, lcf_struct_tmpl, rpg_header_tmpl, rpg_source_tmpl, flags_tmpl, enums_tmpl, fwd_tmpl
 
     structs = get_structs('structs.csv','structs_easyrpg.csv')
     sfields = get_fields('fields.csv','fields_easyrpg.csv')
@@ -453,6 +464,7 @@ def main(argv):
     rpg_source_tmpl = env.get_template('rpg_source.tmpl', globals=globals)
     flags_tmpl = env.get_template('flag_reader.tmpl', globals=globals)
     enums_tmpl = env.get_template('rpg_enums.tmpl', globals=globals)
+    fwd_tmpl = env.get_template('fwd_header.tmpl', globals=globals)
 
     generate()
 

--- a/generator/templates/fwd_header.tmpl
+++ b/generator/templates/fwd_header.tmpl
@@ -1,0 +1,11 @@
+{% include "copyright.tmpl" %}
+// MSVC incorrectly treats these declarations as definitions and fails.
+#ifndef _MSC_VER
+{% for struct in structs -%}
+template <>
+const char* const Struct<RPG::{{ struct }}>::name;
+template <>
+Field<RPG::{{ struct }}> const* Struct<RPG::{{ struct }}>::fields[];
+
+{% endfor -%}
+#endif

--- a/src/generated/fwd_struct_impl.h
+++ b/src/generated/fwd_struct_impl.h
@@ -1,0 +1,344 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2019 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+// MSVC incorrectly treats these declarations as definitions and fails.
+#ifndef _MSC_VER
+template <>
+const char* const Struct<RPG::Actor>::name;
+template <>
+Field<RPG::Actor> const* Struct<RPG::Actor>::fields[];
+
+template <>
+const char* const Struct<RPG::Animation>::name;
+template <>
+Field<RPG::Animation> const* Struct<RPG::Animation>::fields[];
+
+template <>
+const char* const Struct<RPG::AnimationCellData>::name;
+template <>
+Field<RPG::AnimationCellData> const* Struct<RPG::AnimationCellData>::fields[];
+
+template <>
+const char* const Struct<RPG::AnimationFrame>::name;
+template <>
+Field<RPG::AnimationFrame> const* Struct<RPG::AnimationFrame>::fields[];
+
+template <>
+const char* const Struct<RPG::AnimationTiming>::name;
+template <>
+Field<RPG::AnimationTiming> const* Struct<RPG::AnimationTiming>::fields[];
+
+template <>
+const char* const Struct<RPG::Attribute>::name;
+template <>
+Field<RPG::Attribute> const* Struct<RPG::Attribute>::fields[];
+
+template <>
+const char* const Struct<RPG::BattleCommand>::name;
+template <>
+Field<RPG::BattleCommand> const* Struct<RPG::BattleCommand>::fields[];
+
+template <>
+const char* const Struct<RPG::BattleCommands>::name;
+template <>
+Field<RPG::BattleCommands> const* Struct<RPG::BattleCommands>::fields[];
+
+template <>
+const char* const Struct<RPG::BattlerAnimation>::name;
+template <>
+Field<RPG::BattlerAnimation> const* Struct<RPG::BattlerAnimation>::fields[];
+
+template <>
+const char* const Struct<RPG::BattlerAnimationData>::name;
+template <>
+Field<RPG::BattlerAnimationData> const* Struct<RPG::BattlerAnimationData>::fields[];
+
+template <>
+const char* const Struct<RPG::BattlerAnimationExtension>::name;
+template <>
+Field<RPG::BattlerAnimationExtension> const* Struct<RPG::BattlerAnimationExtension>::fields[];
+
+template <>
+const char* const Struct<RPG::Chipset>::name;
+template <>
+Field<RPG::Chipset> const* Struct<RPG::Chipset>::fields[];
+
+template <>
+const char* const Struct<RPG::Class>::name;
+template <>
+Field<RPG::Class> const* Struct<RPG::Class>::fields[];
+
+template <>
+const char* const Struct<RPG::CommonEvent>::name;
+template <>
+Field<RPG::CommonEvent> const* Struct<RPG::CommonEvent>::fields[];
+
+template <>
+const char* const Struct<RPG::Database>::name;
+template <>
+Field<RPG::Database> const* Struct<RPG::Database>::fields[];
+
+template <>
+const char* const Struct<RPG::Encounter>::name;
+template <>
+Field<RPG::Encounter> const* Struct<RPG::Encounter>::fields[];
+
+template <>
+const char* const Struct<RPG::Enemy>::name;
+template <>
+Field<RPG::Enemy> const* Struct<RPG::Enemy>::fields[];
+
+template <>
+const char* const Struct<RPG::EnemyAction>::name;
+template <>
+Field<RPG::EnemyAction> const* Struct<RPG::EnemyAction>::fields[];
+
+template <>
+const char* const Struct<RPG::Equipment>::name;
+template <>
+Field<RPG::Equipment> const* Struct<RPG::Equipment>::fields[];
+
+template <>
+const char* const Struct<RPG::Event>::name;
+template <>
+Field<RPG::Event> const* Struct<RPG::Event>::fields[];
+
+template <>
+const char* const Struct<RPG::EventCommand>::name;
+template <>
+Field<RPG::EventCommand> const* Struct<RPG::EventCommand>::fields[];
+
+template <>
+const char* const Struct<RPG::EventPage>::name;
+template <>
+Field<RPG::EventPage> const* Struct<RPG::EventPage>::fields[];
+
+template <>
+const char* const Struct<RPG::EventPageCondition>::name;
+template <>
+Field<RPG::EventPageCondition> const* Struct<RPG::EventPageCondition>::fields[];
+
+template <>
+const char* const Struct<RPG::Item>::name;
+template <>
+Field<RPG::Item> const* Struct<RPG::Item>::fields[];
+
+template <>
+const char* const Struct<RPG::ItemAnimation>::name;
+template <>
+Field<RPG::ItemAnimation> const* Struct<RPG::ItemAnimation>::fields[];
+
+template <>
+const char* const Struct<RPG::Learning>::name;
+template <>
+Field<RPG::Learning> const* Struct<RPG::Learning>::fields[];
+
+template <>
+const char* const Struct<RPG::Map>::name;
+template <>
+Field<RPG::Map> const* Struct<RPG::Map>::fields[];
+
+template <>
+const char* const Struct<RPG::MapInfo>::name;
+template <>
+Field<RPG::MapInfo> const* Struct<RPG::MapInfo>::fields[];
+
+template <>
+const char* const Struct<RPG::MoveCommand>::name;
+template <>
+Field<RPG::MoveCommand> const* Struct<RPG::MoveCommand>::fields[];
+
+template <>
+const char* const Struct<RPG::MoveRoute>::name;
+template <>
+Field<RPG::MoveRoute> const* Struct<RPG::MoveRoute>::fields[];
+
+template <>
+const char* const Struct<RPG::Music>::name;
+template <>
+Field<RPG::Music> const* Struct<RPG::Music>::fields[];
+
+template <>
+const char* const Struct<RPG::Parameters>::name;
+template <>
+Field<RPG::Parameters> const* Struct<RPG::Parameters>::fields[];
+
+template <>
+const char* const Struct<RPG::Rect>::name;
+template <>
+Field<RPG::Rect> const* Struct<RPG::Rect>::fields[];
+
+template <>
+const char* const Struct<RPG::Save>::name;
+template <>
+Field<RPG::Save> const* Struct<RPG::Save>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveActor>::name;
+template <>
+Field<RPG::SaveActor> const* Struct<RPG::SaveActor>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveCommonEvent>::name;
+template <>
+Field<RPG::SaveCommonEvent> const* Struct<RPG::SaveCommonEvent>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveEasyRpgData>::name;
+template <>
+Field<RPG::SaveEasyRpgData> const* Struct<RPG::SaveEasyRpgData>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveEventExecFrame>::name;
+template <>
+Field<RPG::SaveEventExecFrame> const* Struct<RPG::SaveEventExecFrame>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveEventExecState>::name;
+template <>
+Field<RPG::SaveEventExecState> const* Struct<RPG::SaveEventExecState>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveInventory>::name;
+template <>
+Field<RPG::SaveInventory> const* Struct<RPG::SaveInventory>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveMapEvent>::name;
+template <>
+Field<RPG::SaveMapEvent> const* Struct<RPG::SaveMapEvent>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveMapEventBase>::name;
+template <>
+Field<RPG::SaveMapEventBase> const* Struct<RPG::SaveMapEventBase>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveMapInfo>::name;
+template <>
+Field<RPG::SaveMapInfo> const* Struct<RPG::SaveMapInfo>::fields[];
+
+template <>
+const char* const Struct<RPG::SavePanorama>::name;
+template <>
+Field<RPG::SavePanorama> const* Struct<RPG::SavePanorama>::fields[];
+
+template <>
+const char* const Struct<RPG::SavePartyLocation>::name;
+template <>
+Field<RPG::SavePartyLocation> const* Struct<RPG::SavePartyLocation>::fields[];
+
+template <>
+const char* const Struct<RPG::SavePicture>::name;
+template <>
+Field<RPG::SavePicture> const* Struct<RPG::SavePicture>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveScreen>::name;
+template <>
+Field<RPG::SaveScreen> const* Struct<RPG::SaveScreen>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveSystem>::name;
+template <>
+Field<RPG::SaveSystem> const* Struct<RPG::SaveSystem>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveTarget>::name;
+template <>
+Field<RPG::SaveTarget> const* Struct<RPG::SaveTarget>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveTitle>::name;
+template <>
+Field<RPG::SaveTitle> const* Struct<RPG::SaveTitle>::fields[];
+
+template <>
+const char* const Struct<RPG::SaveVehicleLocation>::name;
+template <>
+Field<RPG::SaveVehicleLocation> const* Struct<RPG::SaveVehicleLocation>::fields[];
+
+template <>
+const char* const Struct<RPG::Skill>::name;
+template <>
+Field<RPG::Skill> const* Struct<RPG::Skill>::fields[];
+
+template <>
+const char* const Struct<RPG::Sound>::name;
+template <>
+Field<RPG::Sound> const* Struct<RPG::Sound>::fields[];
+
+template <>
+const char* const Struct<RPG::Start>::name;
+template <>
+Field<RPG::Start> const* Struct<RPG::Start>::fields[];
+
+template <>
+const char* const Struct<RPG::State>::name;
+template <>
+Field<RPG::State> const* Struct<RPG::State>::fields[];
+
+template <>
+const char* const Struct<RPG::Switch>::name;
+template <>
+Field<RPG::Switch> const* Struct<RPG::Switch>::fields[];
+
+template <>
+const char* const Struct<RPG::System>::name;
+template <>
+Field<RPG::System> const* Struct<RPG::System>::fields[];
+
+template <>
+const char* const Struct<RPG::Terms>::name;
+template <>
+Field<RPG::Terms> const* Struct<RPG::Terms>::fields[];
+
+template <>
+const char* const Struct<RPG::Terrain>::name;
+template <>
+Field<RPG::Terrain> const* Struct<RPG::Terrain>::fields[];
+
+template <>
+const char* const Struct<RPG::TestBattler>::name;
+template <>
+Field<RPG::TestBattler> const* Struct<RPG::TestBattler>::fields[];
+
+template <>
+const char* const Struct<RPG::TreeMap>::name;
+template <>
+Field<RPG::TreeMap> const* Struct<RPG::TreeMap>::fields[];
+
+template <>
+const char* const Struct<RPG::Troop>::name;
+template <>
+Field<RPG::Troop> const* Struct<RPG::Troop>::fields[];
+
+template <>
+const char* const Struct<RPG::TroopMember>::name;
+template <>
+Field<RPG::TroopMember> const* Struct<RPG::TroopMember>::fields[];
+
+template <>
+const char* const Struct<RPG::TroopPage>::name;
+template <>
+Field<RPG::TroopPage> const* Struct<RPG::TroopPage>::fields[];
+
+template <>
+const char* const Struct<RPG::TroopPageCondition>::name;
+template <>
+Field<RPG::TroopPageCondition> const* Struct<RPG::TroopPageCondition>::fields[];
+
+template <>
+const char* const Struct<RPG::Variable>::name;
+template <>
+Field<RPG::Variable> const* Struct<RPG::Variable>::fields[];
+
+#endif

--- a/src/lmt_rect.cpp
+++ b/src/lmt_rect.cpp
@@ -25,6 +25,7 @@ struct RawStruct<RPG::Rect> {
  */
 void RawStruct<RPG::Rect>::ReadLcf(RPG::Rect& ref, LcfReader& stream, uint32_t length) {
 	assert(length == 16);
+	(void)length;
 	stream.Read(ref.l);
 	stream.Read(ref.t);
 	stream.Read(ref.r);

--- a/src/reader_struct_impl.h
+++ b/src/reader_struct_impl.h
@@ -271,3 +271,4 @@ void Struct<S>::BeginXml(std::vector<S>& obj, XmlReader& stream) {
 	stream.SetHandler(new StructVectorXmlHandler<S>(obj));
 }
 
+#include "fwd_struct_impl.h"


### PR DESCRIPTION
Fix: #221

Re-implementation of #290, this time with autogenerated declarations.

Unfortunately, this is still broken with MSVC 2019, so I put ifdefs around it.