### PR TITLE
Rename grid_location to field_depth and add enum

### DIFF
--- a/generator/csv/enums.csv
+++ b/generator/csv/enums.csv
@@ -114,6 +114,9 @@ Terrain,BushDepth,half,2
 Terrain,BushDepth,full,3
 Terrain,BGAssociation,background,0
 Terrain,BGAssociation,frame,1
+Terrain,FieldDepth,custom,0
+Terrain,FieldDepth,shallow,1
+Terrain,FieldDepth,deep,2
 SaveActor,RowType,front,0
 SaveActor,RowType,back,1
 SavePartyLocation,VehicleType,none,0

--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -331,7 +331,7 @@ Terrain,special_back_party,f,Int32,0x29,15,0,1,Integer - RPG2003
 Terrain,special_back_enemies,f,Int32,0x2A,10,0,1,Integer - RPG2003
 Terrain,special_lateral_party,f,Int32,0x2B,10,0,1,Integer - RPG2003
 Terrain,special_lateral_enemies,f,Int32,0x2C,5,0,1,Integer - RPG2003
-Terrain,grid_location,f,Int32,0x2D,0,0,1,Integer - RPG2003
+Terrain,field_depth,f,Enum<Terrain_FieldDepth>,0x2D,0,0,1,Field Depth for terrain presets.
 Terrain,grid_a,f,Int32,0x2E,120,0,1,Integer - RPG2003
 Terrain,grid_b,f,Int32,0x2F,392,0,1,Integer - RPG2003
 Terrain,grid_c,f,Int32,0x30,16000,0,1,Integer - RPG2003

--- a/src/generated/ldb_chunks.h
+++ b/src/generated/ldb_chunks.h
@@ -782,8 +782,8 @@ namespace LDB_Reader {
 			special_lateral_party = 0x2B,
 			/** Integer - RPG2003 */
 			special_lateral_enemies = 0x2C,
-			/** Integer - RPG2003 */
-			grid_location = 0x2D,
+			/** Field Depth for terrain presets. */
+			field_depth = 0x2D,
 			/** Integer - RPG2003 */
 			grid_a = 0x2E,
 			/** Integer - RPG2003 */

--- a/src/generated/ldb_terrain.cpp
+++ b/src/generated/ldb_terrain.cpp
@@ -214,10 +214,10 @@ static TypedField<RPG::Terrain, int32_t> static_special_lateral_enemies(
 	0,
 	1
 );
-static TypedField<RPG::Terrain, int32_t> static_grid_location(
-	&RPG::Terrain::grid_location,
-	LDB_Reader::ChunkTerrain::grid_location,
-	"grid_location",
+static TypedField<RPG::Terrain, int32_t> static_field_depth(
+	&RPG::Terrain::field_depth,
+	LDB_Reader::ChunkTerrain::field_depth,
+	"field_depth",
 	0,
 	1
 );
@@ -274,7 +274,7 @@ Field<RPG::Terrain> const* Struct<RPG::Terrain>::fields[] = {
 	&static_special_back_enemies,
 	&static_special_lateral_party,
 	&static_special_lateral_enemies,
-	&static_grid_location,
+	&static_field_depth,
 	&static_grid_a,
 	&static_grid_b,
 	&static_grid_c,

--- a/src/generated/rpg_enums.cpp
+++ b/src/generated/rpg_enums.cpp
@@ -71,6 +71,7 @@ constexpr decltype(EnemyAction::kBasicTags) EnemyAction::kBasicTags;
 constexpr decltype(EnemyAction::kConditionTypeTags) EnemyAction::kConditionTypeTags;
 constexpr decltype(Terrain::kBushDepthTags) Terrain::kBushDepthTags;
 constexpr decltype(Terrain::kBGAssociationTags) Terrain::kBGAssociationTags;
+constexpr decltype(Terrain::kFieldDepthTags) Terrain::kFieldDepthTags;
 constexpr decltype(State::kPersistenceTags) State::kPersistenceTags;
 constexpr decltype(State::kRestrictionTags) State::kRestrictionTags;
 constexpr decltype(State::kAffectTypeTags) State::kAffectTypeTags;

--- a/src/generated/rpg_terrain.h
+++ b/src/generated/rpg_terrain.h
@@ -45,6 +45,16 @@ namespace RPG {
 			"background",
 			"frame"
 		);
+		enum FieldDepth {
+			FieldDepth_custom = 0,
+			FieldDepth_shallow = 1,
+			FieldDepth_deep = 2
+		};
+		static constexpr auto kFieldDepthTags = makeEnumTags<FieldDepth>(
+			"custom",
+			"shallow",
+			"deep"
+		);
 
 		int ID = 0;
 		std::string name;
@@ -88,7 +98,7 @@ namespace RPG {
 		int32_t special_back_enemies = 10;
 		int32_t special_lateral_party = 10;
 		int32_t special_lateral_enemies = 5;
-		int32_t grid_location = 0;
+		int32_t field_depth = 0;
 		int32_t grid_a = 120;
 		int32_t grid_b = 392;
 		int32_t grid_c = 16000;
@@ -131,7 +141,7 @@ namespace RPG {
 		&& l.special_back_enemies == r.special_back_enemies
 		&& l.special_lateral_party == r.special_lateral_party
 		&& l.special_lateral_enemies == r.special_lateral_enemies
-		&& l.grid_location == r.grid_location
+		&& l.field_depth == r.field_depth
 		&& l.grid_a == r.grid_a
 		&& l.grid_b == r.grid_b
 		&& l.grid_c == r.grid_c;

--- a/tests/flag_set.cpp
+++ b/tests/flag_set.cpp
@@ -60,7 +60,9 @@ TEST_CASE("Logical Ops") {
 	REQUIRE(cs0 == (csr & csg));
 	REQUIRE(cs0 == (csb & csg));
 	REQUIRE(cs0 == (csr & csb));
+	REQUIRE(cs0 == (csrg & csb));
 	REQUIRE(cs0 == (csrb & csg));
+	REQUIRE(cs0 == (csgb & csr));
 	REQUIRE(cs0 == (csrgb & cs0));
 
 	REQUIRE(csrb == (csr | csb));


### PR DESCRIPTION
This chunk is the one labeled "Field Depth" in the terrain editor. If you customize the grid, it becomes deselected and goes to 0.

Shallow is 1 and deep is 2. This is also selectible from EnemyEncounter command.