### PR TITLE
Enable the GNU extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 # C++14 is required
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS ON)
 
 # lcf library files
 add_library(lcf

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ liblcf_la_CPPFLAGS = \
 	-I$(srcdir)/src \
 	-I$(srcdir)/src/generated
 liblcf_la_CXXFLAGS = \
-	-std=c++14 \
+	-std=gnu++14 \
 	-fno-math-errno \
 	$(AM_CXXFLAGS) \
 	$(EXPAT_CFLAGS) \
@@ -228,7 +228,7 @@ test_runner_CPPFLAGS = \
 	-I$(srcdir)/src \
 	-I$(srcdir)/src/generated
 test_runner_CXXFLAGS = \
-	-std=c++14 \
+	-std=gnu++14 \
 	$(EXPAT_CXXFLAGS) \
 	$(ICU_CXXFLAGS)
 test_runner_LDADD = \


### PR DESCRIPTION
I'd like to get this nastiness:
https://github.com/EasyRPG/liblcf/blob/master/src/writer_xml.cpp#L12
The problem is what `-std=c++11` defines `__STRICT_ANSI__` which causes a lot of functions to go undeclared on AmigaOS4. I made this a separate PR in case it causes any problems. 