### PR TITLE
Add editorconfig file to avoid whitespace problems

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = tab
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_style = space
+indent_size = 4
+
+[*.sh]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This is a modern approach to modelines and such.
This is not about linting, just to set sane editor defaults.

For more information, see https://editorconfig.org