### PR TITLE
Fix generated fwd.h header

### DIFF
--- a/src/generated/lcf/rpg/fwd.h
+++ b/src/generated/lcf/rpg/fwd.h
@@ -12,8 +12,6 @@
 #ifndef LCF_RPG_FWD_H
 #define LCF_RPG_FWD_H
 
-#include <lcf/fwd.h>
-
 namespace lcf {
 namespace rpg {
 	class Actor;


### PR DESCRIPTION
There was a bug in fwd.h from previous PR. The generated header included in the PR was an older version. This regenerates the header and fixes it.