### PR TITLE
Force nonstd string_view and span to fix C++17/20 interop

### DIFF
--- a/src/dbarray.cpp
+++ b/src/dbarray.cpp
@@ -12,7 +12,7 @@
 
 namespace lcf {
 
-constexpr DBArrayAlloc::size_type DBArrayAlloc::_empty_buf;
+constexpr DBArrayAlloc::size_type DBArrayAlloc::_empty_buf[2];
 constexpr DBString::size_type DBString::npos;
 
 static ptrdiff_t HeaderSize(size_t align) {

--- a/src/lcf/dbarrayalloc.h
+++ b/src/lcf/dbarrayalloc.h
@@ -27,7 +27,7 @@ struct DBArrayAlloc {
 	static void free(void* p, size_type align) noexcept;
 
 	static constexpr void* empty_buf() {
-		return const_cast<size_type*>(&_empty_buf + 1);
+		return const_cast<size_type*>(&_empty_buf[1]);
 	}
 
 	static constexpr size_type* get_size_ptr(void* p) {
@@ -39,7 +39,7 @@ struct DBArrayAlloc {
 	}
 
 	private:
-	static constexpr const size_type _empty_buf = 0;
+	static constexpr const size_type _empty_buf[2] = { 0, 0 };
 };
 
 } // namespace lcf

--- a/src/lcf/span.h
+++ b/src/lcf/span.h
@@ -20,6 +20,7 @@
 #define span_FEATURE_WITH_CONTAINER 1
 #define span_FEATURE_CONSTRUCTION_FROM_STDARRAY_ELEMENT_TYPE 1
 #define span_FEATURE_MAKE_SPAN 1
+#define span_CONFIG_SLECT_SPAN span_SPAN_NONSTD
 #include <lcf/third_party/span.h>
 
 namespace lcf {

--- a/src/lcf/string_view.h
+++ b/src/lcf/string_view.h
@@ -18,6 +18,7 @@
 
 #define nssv_CONFIG_NO_EXCEPTIONS 1
 #define nssv_CONFIG_CONVERSION_STD_STRING 1
+#define nssv_CONFIG_SELECT_STRING_VIEW nssv_STRING_VIEW_NONSTD
 #include <lcf/third_party/string_view.h>
 
 namespace lcf {


### PR DESCRIPTION
Fix: #398