### PR TITLE
make _empty_buf const instead of constexpr

### DIFF
--- a/src/dbarray.cpp
+++ b/src/dbarray.cpp
@@ -12,7 +12,7 @@
 
 namespace lcf {
 
-constexpr DBArrayAlloc::size_type DBArrayAlloc::_empty_buf[2];
+const DBArrayAlloc::size_type DBArrayAlloc::_empty_buf[2] = { 0, 0 };
 constexpr DBString::size_type DBString::npos;
 
 static ptrdiff_t HeaderSize(size_t align) {

--- a/src/lcf/dbarrayalloc.h
+++ b/src/lcf/dbarrayalloc.h
@@ -26,7 +26,7 @@ struct DBArrayAlloc {
 	static void* alloc(size_type size, size_type field_size, size_type align);
 	static void free(void* p, size_type align) noexcept;
 
-	static constexpr void* empty_buf() {
+	static void* empty_buf() {
 		return const_cast<size_type*>(&_empty_buf[1]);
 	}
 
@@ -39,7 +39,7 @@ struct DBArrayAlloc {
 	}
 
 	private:
-	static constexpr const size_type _empty_buf[2] = { 0, 0 };
+	static const size_type _empty_buf[2];
 };
 
 } // namespace lcf


### PR DESCRIPTION
C++17 made constexpr implicity inline which gives linker errors here because lcf is compiled as C++14 but Editor is C++17

see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0386r2

Fixes linking with g++ and makes clang++ ASAN happy.