### PR TITLE
Move lcf::Data out of parser implementations

### DIFF
--- a/generator/csv/functions.csv
+++ b/generator/csv/functions.csv
@@ -1,3 +1,3 @@
 Structure,Method,Headers
-Actor,void Setup(),
+Actor,void Setup(bool is2k3),
 Parameters,void Setup(int final_level),

--- a/src/generated/lcf/rpg/actor.h
+++ b/src/generated/lcf/rpg/actor.h
@@ -30,7 +30,7 @@ namespace lcf {
 namespace rpg {
 	class Actor {
 	public:
-		void Setup();
+		void Setup(bool is2k3);
 		int ID = 0;
 		DBString name;
 		DBString title;

--- a/src/lcf/writer_lcf.h
+++ b/src/lcf/writer_lcf.h
@@ -36,9 +36,10 @@ public:
 	 * Constructs a new File Writer.
 	 *
 	 * @param filestream already opened filestream.
+	 * @param is2k3 Write in RPG2003 format.
 	 * @param encoding name of the encoding.
 	 */
-	LcfWriter(std::ostream& filestream, std::string encoding = "");
+	LcfWriter(std::ostream& filestream, bool is2k3, std::string encoding = "");
 
 	/**
 	 * Destructor. Closes the opened file.
@@ -117,11 +118,16 @@ public:
 	 */
 	std::string Decode(StringView str_to_encode);
 
+	/** @return true if 2k3 format, false if 2k format */
+	bool Is2k3() const;
+
 private:
 	/** File-stream managed by this Writer. */
 	std::ostream& stream;
 	/** Encoder object */
 	Encoder encoder;
+	/** Writing 2k3 format */
+	bool is2k3;
 
 	/**
 	 * Converts a 16bit signed integer to/from little-endian.
@@ -159,6 +165,10 @@ private:
 	static void SwapByteOrder(double &d);
 
 };
+
+inline bool LcfWriter::Is2k3() const {
+	return is2k3;
+}
 
 } //namespace lcf
 

--- a/src/lcf/writer_xml.h
+++ b/src/lcf/writer_xml.h
@@ -30,8 +30,9 @@ public:
 	 * Constructs a new XML File Writer.
 	 *
 	 * @param filestream already opened filestream.
+	 * @param is2k3 Write in RPG2003 format.
 	 */
-	XmlWriter(std::ostream& filestream);
+	XmlWriter(std::ostream& filestream, bool is2k3);
 
 	/**
 	 * Destructor. Closes the opened file.
@@ -103,6 +104,9 @@ public:
 	 */
 	bool IsOk() const;
 
+	/** @return true if 2k3 format, false if 2k format */
+	bool Is2k3() const;
+
 protected:
 	/** File-stream managed by this Writer. */
 	std::ostream& stream;
@@ -110,6 +114,8 @@ protected:
 	int indent;
 	/** Indicates if writer cursor is at the beginning of the line. */
 	bool at_bol;
+	/** Writing 2k3 format */
+	bool is2k3;
 
 	/**
 	 * Writes an indentation to the stream.
@@ -126,6 +132,11 @@ protected:
 
 	void WriteString(StringView s);
 };
+
+inline bool XmlWriter::Is2k3() const {
+	return is2k3;
+}
+
 
 } //namespace lcf
 

--- a/src/ldb_reader.cpp
+++ b/src/ldb_reader.cpp
@@ -87,7 +87,7 @@ bool LDB_Reader::Load(std::istream& filestream, const std::string& encoding) {
 }
 
 bool LDB_Reader::Save(std::ostream& filestream, const std::string& encoding, SaveOpt opt) {
-	LcfWriter writer(filestream, encoding);
+	LcfWriter writer(filestream, Data::system.ldb_id == 2003, encoding);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse database file.\n");
 		return false;
@@ -105,7 +105,7 @@ bool LDB_Reader::Save(std::ostream& filestream, const std::string& encoding, Sav
 }
 
 bool LDB_Reader::SaveXml(std::ostream& filestream) {
-	XmlWriter writer(filestream);
+	XmlWriter writer(filestream, Data::system.ldb_id == 2003);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse database file.\n");
 		return false;

--- a/src/ldb_reader.cpp
+++ b/src/ldb_reader.cpp
@@ -79,9 +79,8 @@ bool LDB_Reader::Load(std::istream& filestream, const std::string& encoding) {
 
 	// Delayed initialization of some actor fields because they are engine
 	// dependent
-	std::vector<rpg::Actor>::iterator it;
-	for (it = Data::actors.begin(); it != Data::actors.end(); ++it) {
-		(*it).Setup();
+	for (auto& actor: Data::actors) {
+		actor.Setup(Data::system.ldb_id == 2003);
 	}
 
 	return true;

--- a/src/lmt_reader.cpp
+++ b/src/lmt_reader.cpp
@@ -76,7 +76,7 @@ bool LMT_Reader::Load(std::istream& filestream, const std::string &encoding) {
 }
 
 bool LMT_Reader::Save(std::ostream& filestream, const std::string &encoding, SaveOpt opt) {
-	LcfWriter writer(filestream, encoding);
+	LcfWriter writer(filestream, Data::system.ldb_id == 2003, encoding);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse map tree file.\n");
 		return false;
@@ -94,7 +94,7 @@ bool LMT_Reader::Save(std::ostream& filestream, const std::string &encoding, Sav
 }
 
 bool LMT_Reader::SaveXml(std::ostream& filestream) {
-	XmlWriter writer(filestream);
+	XmlWriter writer(filestream, Data::system.ldb_id == 2003);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse map tree file.\n");
 		return false;

--- a/src/lmu_reader.cpp
+++ b/src/lmu_reader.cpp
@@ -15,6 +15,7 @@
 #include "lcf/lmu/chunks.h"
 #include "lcf/reader_lcf.h"
 #include "lcf/reader_util.h"
+#include "lcf/data.h"
 #include "reader_struct.h"
 
 namespace lcf {
@@ -82,7 +83,7 @@ std::unique_ptr<rpg::Map> LMU_Reader::Load(std::istream& filestream, const std::
 }
 
 bool LMU_Reader::Save(std::ostream& filestream, const rpg::Map& map, const std::string& encoding, SaveOpt opt) {
-	LcfWriter writer(filestream, encoding);
+	LcfWriter writer(filestream, Data::system.ldb_id == 2003, encoding);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse map file.\n");
 		return false;
@@ -101,7 +102,7 @@ bool LMU_Reader::Save(std::ostream& filestream, const rpg::Map& map, const std::
 }
 
 bool LMU_Reader::SaveXml(std::ostream& filestream, const rpg::Map& map) {
-	XmlWriter writer(filestream);
+	XmlWriter writer(filestream, Data::system.ldb_id == 2003);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse map file.\n");
 		return false;

--- a/src/lsd_reader.cpp
+++ b/src/lsd_reader.cpp
@@ -16,6 +16,7 @@
 #include "lcf/lsd/chunks.h"
 #include "lcf/rpg/save.h"
 #include "lcf/reader_util.h"
+#include "lcf/data.h"
 #include "reader_struct.h"
 
 namespace lcf {
@@ -96,7 +97,7 @@ std::unique_ptr<rpg::Save> LSD_Reader::Load(std::istream& filestream, const std:
 }
 
 bool LSD_Reader::Save(std::ostream& filestream, const rpg::Save& save, const std::string &encoding) {
-	LcfWriter writer(filestream, encoding);
+	LcfWriter writer(filestream, Data::system.ldb_id == 2003, encoding);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse save file.\n");
 		return false;
@@ -110,7 +111,7 @@ bool LSD_Reader::Save(std::ostream& filestream, const rpg::Save& save, const std
 }
 
 bool LSD_Reader::SaveXml(std::ostream& filestream, const rpg::Save& save) {
-	XmlWriter writer(filestream);
+	XmlWriter writer(filestream, Data::system.ldb_id == 2003);
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse save file.\n");
 		return false;

--- a/src/reader_flags.cpp
+++ b/src/reader_flags.cpp
@@ -12,7 +12,6 @@
 #include "lcf/rpg/eventpagecondition.h"
 #include "lcf/rpg/terrain.h"
 #include "lcf/rpg/savepicture.h"
-#include "lcf/data.h"
 
 #include "ldb_trooppagecondition_flags.h"
 #include "ldb_terrain_flags.h"
@@ -51,7 +50,7 @@ void Flags<S>::ReadLcf(S& obj, LcfReader& stream, uint32_t length) {
 
 template <class S>
 void Flags<S>::WriteLcf(const S& obj, LcfWriter& stream) {
-	const bool db_is2k3 = (Data::system.ldb_id == 2003);
+	const bool db_is2k3 = stream.Is2k3();
 
 	uint8_t byte = 0;
 	int bitidx = 0;
@@ -76,8 +75,8 @@ void Flags<S>::WriteLcf(const S& obj, LcfWriter& stream) {
 }
 
 template <class S>
-int Flags<S>::LcfSize(const S& /* obj */, LcfWriter& /* stream */) {
-	const bool db_is2k3 = (Data::system.ldb_id == 2003);
+int Flags<S>::LcfSize(const S& /* obj */, LcfWriter& stream) {
+	const bool db_is2k3 = stream.Is2k3();
 	int num_bits = 0;
 	for (size_t i = 0; i < num_flags; ++i) {
 		const auto flag_is2k3 = flags_is2k3[i];
@@ -92,7 +91,7 @@ int Flags<S>::LcfSize(const S& /* obj */, LcfWriter& /* stream */) {
 
 template <class S>
 void Flags<S>::WriteXml(const S& obj, XmlWriter& stream) {
-	const bool db_is2k3 = (Data::system.ldb_id == 2003);
+	const bool db_is2k3 = stream.Is2k3();
 	stream.BeginElement(name);
 	for (size_t i = 0; i < num_flags; ++i) {
 		const auto flag_is2k3 = flags_is2k3[i];

--- a/src/reader_struct.h
+++ b/src/reader_struct.h
@@ -36,7 +36,6 @@
 #include "lcf/rpg/rect.h"
 #include "lcf/rpg/savepicture.h"
 #include "lcf/rpg/terms.h"
-#include "lcf/data.h"
 
 namespace lcf {
 
@@ -410,7 +409,7 @@ struct Field {
 	virtual void ReadLcf(S& obj, LcfReader& stream, uint32_t length) const = 0;
 	virtual void WriteLcf(const S& obj, LcfWriter& stream) const = 0;
 	virtual int LcfSize(const S& obj, LcfWriter& stream) const = 0;
-	virtual bool IsDefault(const S& obj, const S& ref) const = 0;
+	virtual bool IsDefault(const S& obj, const S& ref, bool is2k3) const = 0;
 	virtual void WriteXml(const S& obj, XmlWriter& stream) const = 0;
 	virtual void BeginXml(S& obj, XmlReader& stream) const = 0;
 	virtual void ParseXml(S& obj, const std::string& data) const = 0;
@@ -455,7 +454,7 @@ struct TypedField : public Field<S> {
 	void ParseXml(S& obj, const std::string& data) const {
 		TypeReader<T>::ParseXml(obj.*ref, data);
 	}
-	bool IsDefault(const S& a, const S& b) const {
+	bool IsDefault(const S& a, const S& b, bool) const {
 		return a.*ref == b.*ref;
 	}
 
@@ -479,13 +478,13 @@ struct DatabaseVersionField : public TypedField<S,T> {
 		}
 		return TypedField<S,T>::LcfSize(obj, stream);
 	}
-	bool IsDefault(const S& a, const S& b) const {
-		if (Data::system.ldb_id == 2003) {
+	bool IsDefault(const S& a, const S& b, bool is2k3) const {
+		if (is2k3) {
 			//DB Version always present in 2k3 db
 			return false;
 		}
 		//Only present if not 0 in 2k db.
-		return TypedField<S,T>::IsDefault(a, b);
+		return TypedField<S,T>::IsDefault(a, b, is2k3);
 	}
 };
 
@@ -508,7 +507,7 @@ struct EmptyField : public Field<S> {
 	void BeginXml(S& /* obj */, XmlReader& /* stream */) const { }
 	void ParseXml(S& /* obj */, const std::string& /* data */) const { }
 
-	bool IsDefault(const S& /* a */, const S& /* b */) const {
+	bool IsDefault(const S& /* a */, const S& /* b */, bool) const {
 		return true;
 	}
 
@@ -544,7 +543,7 @@ struct SizeField : public Field<S> {
 	void ParseXml(S& /* obj */, const std::string& /* data */) const {
 		// no-op
 	}
-	bool IsDefault(const S& a, const S& b) const {
+	bool IsDefault(const S& a, const S& b, bool) const {
 		return (a.*ref).size() == (b.*ref).size();
 	}
 

--- a/src/reader_struct_impl.h
+++ b/src/reader_struct_impl.h
@@ -17,7 +17,6 @@
 #include "lcf/lsd/reader.h"
 #include "reader_struct.h"
 #include "lcf/rpg/save.h"
-#include "lcf/data.h"
 
 namespace lcf {
 
@@ -106,7 +105,7 @@ conditional_zero_writer(LcfWriter& stream) {
 
 template <class S>
 void Struct<S>::WriteLcf(const S& obj, LcfWriter& stream) {
-	const bool db_is2k3 = (Data::system.ldb_id == 2003);
+	const bool db_is2k3 = stream.Is2k3();
 
 	auto ref = StructDefault<S>::make(db_is2k3);
 	int last = -1;
@@ -136,7 +135,7 @@ void Struct<S>::WriteLcf(const S& obj, LcfWriter& stream) {
 
 template <class S>
 int Struct<S>::LcfSize(const S& obj, LcfWriter& stream) {
-	const bool db_is2k3 = (Data::system.ldb_id == 2003);
+	const bool db_is2k3 = stream.Is2k3();
 	int result = 0;
 	auto ref = StructDefault<S>::make(db_is2k3);
 	for (int i = 0; fields[i] != NULL; i++) {

--- a/src/reader_struct_impl.h
+++ b/src/reader_struct_impl.h
@@ -119,7 +119,7 @@ void Struct<S>::WriteLcf(const S& obj, LcfWriter& stream) {
 					  << " after " << last
 					  << " in struct " << name
 					  << std::endl;
-		if (!field->isPresentIfDefault(db_is2k3) && field->IsDefault(obj, ref)) {
+		if (!field->isPresentIfDefault(db_is2k3) && field->IsDefault(obj, ref, db_is2k3)) {
 			continue;
 		}
 		stream.WriteInt(field->id);
@@ -144,7 +144,7 @@ int Struct<S>::LcfSize(const S& obj, LcfWriter& stream) {
 			continue;
 		}
 		//printf("%s\n", field->name);
-		if (!field->isPresentIfDefault(db_is2k3) && field->IsDefault(obj, ref)) {
+		if (!field->isPresentIfDefault(db_is2k3) && field->IsDefault(obj, ref, db_is2k3)) {
 			continue;
 		}
 		result += LcfReader::IntSize(field->id);

--- a/src/reader_struct_impl.h
+++ b/src/reader_struct_impl.h
@@ -41,19 +41,21 @@ void Struct<S>::MakeTagMap() {
 
 template <typename T>
 struct StructDefault {
-	static T make() {
+	static T make(bool) {
 		return T();
 	}
 };
 
 template <>
 struct StructDefault<rpg::Actor> {
-	static rpg::Actor make() {
+	static rpg::Actor make(bool is2k3) {
 		auto actor = rpg::Actor();
-		actor.Setup();
+		actor.Setup(is2k3);
 		return actor;
 	}
 };
+
+
 
 template <class S>
 void Struct<S>::ReadLcf(S& obj, LcfReader& stream) {
@@ -106,7 +108,7 @@ template <class S>
 void Struct<S>::WriteLcf(const S& obj, LcfWriter& stream) {
 	const bool db_is2k3 = (Data::system.ldb_id == 2003);
 
-	auto ref = StructDefault<S>::make();
+	auto ref = StructDefault<S>::make(db_is2k3);
 	int last = -1;
 	for (int i = 0; fields[i] != NULL; i++) {
 		const Field<S>* field = fields[i];
@@ -136,7 +138,7 @@ template <class S>
 int Struct<S>::LcfSize(const S& obj, LcfWriter& stream) {
 	const bool db_is2k3 = (Data::system.ldb_id == 2003);
 	int result = 0;
-	auto ref = StructDefault<S>::make();
+	auto ref = StructDefault<S>::make(db_is2k3);
 	for (int i = 0; fields[i] != NULL; i++) {
 		const Field<S>* field = fields[i];
 		if (!db_is2k3 && field->is2k3) {

--- a/src/rpg_setup.cpp
+++ b/src/rpg_setup.cpp
@@ -16,13 +16,12 @@
 #include "lcf/rpg/save.h"
 #include "lcf/rpg/chipset.h"
 #include "lcf/rpg/parameters.h"
-#include "lcf/data.h"
 
 namespace lcf {
 
-void rpg::Actor::Setup() {
+void rpg::Actor::Setup(bool is2k3) {
 	int max_final_level = 0;
-	if (lcf::Data::system.ldb_id == 2003) {
+	if (is2k3) {
 		max_final_level = 99;
 		if (final_level == -1) {
 			final_level = max_final_level;

--- a/src/writer_lcf.cpp
+++ b/src/writer_lcf.cpp
@@ -13,9 +13,10 @@
 
 namespace lcf {
 
-LcfWriter::LcfWriter(std::ostream& filestream, std::string encoding)
+LcfWriter::LcfWriter(std::ostream& filestream, bool is2k3, std::string encoding)
 	: stream(filestream)
 	, encoder(std::move(encoding))
+	, is2k3(is2k3)
 {
 }
 

--- a/src/writer_xml.cpp
+++ b/src/writer_xml.cpp
@@ -17,10 +17,11 @@
 
 namespace lcf {
 
-XmlWriter::XmlWriter(std::ostream& filestream) :
+XmlWriter::XmlWriter(std::ostream& filestream, bool is2k3) :
 	stream(filestream),
 	indent(0),
-	at_bol(true)
+	at_bol(true),
+	is2k3(is2k3)
 {
 	stream << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
 }


### PR DESCRIPTION
Preparation for removing globals from liblcf. This change only moves `lcf::Data` out to the edges. Player and Editor are not affected by this.

Next PR will remove `lcf::Data`
 
TBD:

- [x] Test reading/writing 2k and 2k3 LDB, LMT, LMU, LSD files to ensure no breaks

