### PR TITLE
Make some hardcoded terms customizable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(LCF_SOURCES
 	src/reader_util.cpp
 	src/reader_xml.cpp
 	src/rpg_setup.cpp
+	src/rpg_terms.cpp
 	src/saveopt.cpp
 	src/writer_lcf.cpp
 	src/writer_xml.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,7 @@ liblcf_la_SOURCES = \
 	src/reader_util.cpp \
 	src/reader_xml.cpp \
 	src/rpg_setup.cpp \
+	src/rpg_terms.cpp \
 	src/saveopt.cpp \
 	src/writer_lcf.cpp \
 	src/writer_xml.cpp \

--- a/generator/csv/constants.csv
+++ b/generator/csv/constants.csv
@@ -4,3 +4,4 @@ SavePartyLocation,kPanXDefault,int,9 * 256,Equal to 9 tiles in 1/16th pixels
 SavePartyLocation,kPanYDefault,int,7 * 256,Equal to 7 tiles in 1/16th pixels
 SavePartyLocation,kPanSpeedDefault,int,2 << 3,Frame speed in 1/16th pixels
 SaveActor,kEmptyName,const char*,"""\x1""",Sentinel name used to denote that the default LDB name should be used.
+Terms,kDefaultTerm,const char*,"""default_term""",Sentinel name used to denote that the default hardcoded term should be used.

--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -1,3 +1,21 @@
 Structure,Field,Size Field?,Type,Index,Default Value,PersistIfDefault,Is2k3,Comment
-Save,easyrpg_data,f,SaveEasyRpgData,0xc8,,0,0,Additional save data written by EasyRPG Player
+Save,easyrpg_data,f,SaveEasyRpgData,0xC8,,0,0,Additional save data written by EasyRPG Player
 SaveEasyRpgData,version,,Int32,1,0,0,0,Savegame version
+Terms,easyrpg_item_number_separator,f,DBString,0xC8,DBString(kDefaultTerm),0,0,Item number separator
+Terms,easyrpg_skill_cost_separator,f,DBString,0xC9,DBString(kDefaultTerm),0,0,Skill cost separator
+Terms,easyrpg_equipment_arrow,f,DBString,0xCA,DBString(kDefaultTerm),0,0,Equipment window arrow
+Terms,easyrpg_status_scene_name,f,DBString,0xCB,DBString(kDefaultTerm),0,1,Status scene Name
+Terms,easyrpg_status_scene_class,f,DBString,0xCC,DBString(kDefaultTerm),0,1,Status scene Class
+Terms,easyrpg_status_scene_title,f,DBString,0xCD,DBString(kDefaultTerm),0,1,Status scene Title
+Terms,easyrpg_status_scene_condition,f,DBString,0xCE,DBString(kDefaultTerm),0,1,Status scene Condition
+Terms,easyrpg_status_scene_front,f,DBString,0xCF,DBString(kDefaultTerm),0,1,Status scene Front
+Terms,easyrpg_status_scene_back,f,DBString,0xD0,DBString(kDefaultTerm),0,1,Status scene Back
+Terms,easyrpg_order_scene_confirm,f,DBString,0xD1,DBString(kDefaultTerm),0,1,Order scene Confirm
+Terms,easyrpg_order_scene_redo,f,DBString,0xD2,DBString(kDefaultTerm),0,1,Order scene Redo
+Terms,easyrpg_battle2k3_double_attack,f,DBString,0xD3,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle monster Double attack notification
+Terms,easyrpg_battle2k3_defend,f,DBString,0xD4,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle monster Defend notification
+Terms,easyrpg_battle2k3_observe,f,DBString,0xD5,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle monster Observe notification
+Terms,easyrpg_battle2k3_charge,f,DBString,0xD6,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle monster Charge notification
+Terms,easyrpg_battle2k3_selfdestruct,f,DBString,0xD7,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle monster Self-Destruct notification
+Terms,easyrpg_battle2k3_escape,f,DBString,0xD8,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle monster Escape notification
+Terms,easyrpg_battle2k3_special_combat_back,f,DBString,0xD9,,0,1,Message for back and pincer attack

--- a/generator/csv/functions.csv
+++ b/generator/csv/functions.csv
@@ -1,3 +1,4 @@
-Structure,Method,Headers
-Actor,void Setup(bool is2k3),
-Parameters,void Setup(int final_level),
+Structure,Method,Static,Headers
+Actor,void Setup(bool is2k3),f,
+Parameters,void Setup(int final_level),f,
+Terms,"std::string TermOrDefault(const DBString& db_term, StringView default_term)",t,

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -321,8 +321,22 @@ def get_flags(*filenames):
     return merge_dicts(results)
 
 def get_functions(*filenames):
-    results = list(map(lambda x: process_file(x, namedtuple("Function", "method headers")), filenames))
-    return merge_dicts(results)
+    Function = namedtuple("Function", "method static headers")
+
+    results = list(map(lambda x: process_file(x, Function), filenames))
+
+    processed_result = OrderedDict()
+
+    for k, field in merge_dicts(results).items():
+        processed_result[k] = []
+        for elem in field:
+            elem = Function(
+                elem.method,
+                elem.static == 't',
+                elem.headers)
+            processed_result[k].append(elem)
+
+    return processed_result
 
 def get_constants(filename='constants.csv'):
     return process_file(filename, namedtuple("Constant", "name type value comment"))

--- a/generator/templates/rpg_header.tmpl
+++ b/generator/templates/rpg_header.tmpl
@@ -56,7 +56,7 @@ namespace rpg {
 	{%- endfor %}
 	{% endif %}
 	{%- for func in functions[struct_name] %}
-		{{ func.method }};
+		{%+ if func.static %}static {% endif %}{{ func.method }};
 	{%- endfor %}
 	{%- if has_id %}
 		int ID = 0;

--- a/src/generated/lcf/ldb/chunks.h
+++ b/src/generated/lcf/ldb/chunks.h
@@ -1141,7 +1141,43 @@ namespace LDB_Reader {
 			/** String */
 			yes = 0x98,
 			/** String */
-			no = 0x99
+			no = 0x99,
+			/** Item number separator */
+			easyrpg_item_number_separator = 0xC8,
+			/** Skill cost separator */
+			easyrpg_skill_cost_separator = 0xC9,
+			/** Equipment window arrow */
+			easyrpg_equipment_arrow = 0xCA,
+			/** Status scene Name */
+			easyrpg_status_scene_name = 0xCB,
+			/** Status scene Class */
+			easyrpg_status_scene_class = 0xCC,
+			/** Status scene Title */
+			easyrpg_status_scene_title = 0xCD,
+			/** Status scene Condition */
+			easyrpg_status_scene_condition = 0xCE,
+			/** Status scene Front */
+			easyrpg_status_scene_front = 0xCF,
+			/** Status scene Back */
+			easyrpg_status_scene_back = 0xD0,
+			/** Order scene Confirm */
+			easyrpg_order_scene_confirm = 0xD1,
+			/** Order scene Redo */
+			easyrpg_order_scene_redo = 0xD2,
+			/** RPG Maker 2003 battle monster Double attack notification */
+			easyrpg_battle2k3_double_attack = 0xD3,
+			/** RPG Maker 2003 battle monster Defend notification */
+			easyrpg_battle2k3_defend = 0xD4,
+			/** RPG Maker 2003 battle monster Observe notification */
+			easyrpg_battle2k3_observe = 0xD5,
+			/** RPG Maker 2003 battle monster Charge notification */
+			easyrpg_battle2k3_charge = 0xD6,
+			/** RPG Maker 2003 battle monster Self-Destruct notification */
+			easyrpg_battle2k3_selfdestruct = 0xD7,
+			/** RPG Maker 2003 battle monster Escape notification */
+			easyrpg_battle2k3_escape = 0xD8,
+			/** Message for back and pincer attack */
+			easyrpg_battle2k3_special_combat_back = 0xD9
 		};
 	};
 	struct ChunkMusic {

--- a/src/generated/lcf/rpg/terms.h
+++ b/src/generated/lcf/rpg/terms.h
@@ -25,6 +25,9 @@ namespace lcf {
 namespace rpg {
 	class Terms {
 	public:
+		// Sentinel name used to denote that the default hardcoded term should be used.
+		static constexpr const char* kDefaultTerm = "default_term";
+
 		DBString encounter;
 		DBString special_combat;
 		DBString escape_success;
@@ -152,6 +155,24 @@ namespace rpg {
 		DBString exit_game_message;
 		DBString yes;
 		DBString no;
+		DBString easyrpg_item_number_separator = DBString(kDefaultTerm);
+		DBString easyrpg_skill_cost_separator = DBString(kDefaultTerm);
+		DBString easyrpg_equipment_arrow = DBString(kDefaultTerm);
+		DBString easyrpg_status_scene_name = DBString(kDefaultTerm);
+		DBString easyrpg_status_scene_class = DBString(kDefaultTerm);
+		DBString easyrpg_status_scene_title = DBString(kDefaultTerm);
+		DBString easyrpg_status_scene_condition = DBString(kDefaultTerm);
+		DBString easyrpg_status_scene_front = DBString(kDefaultTerm);
+		DBString easyrpg_status_scene_back = DBString(kDefaultTerm);
+		DBString easyrpg_order_scene_confirm = DBString(kDefaultTerm);
+		DBString easyrpg_order_scene_redo = DBString(kDefaultTerm);
+		DBString easyrpg_battle2k3_double_attack = DBString(kDefaultTerm);
+		DBString easyrpg_battle2k3_defend = DBString(kDefaultTerm);
+		DBString easyrpg_battle2k3_observe = DBString(kDefaultTerm);
+		DBString easyrpg_battle2k3_charge = DBString(kDefaultTerm);
+		DBString easyrpg_battle2k3_selfdestruct = DBString(kDefaultTerm);
+		DBString easyrpg_battle2k3_escape = DBString(kDefaultTerm);
+		DBString easyrpg_battle2k3_special_combat_back;
 	};
 
 	inline bool operator==(const Terms& l, const Terms& r) {
@@ -281,7 +302,25 @@ namespace rpg {
 		&& l.file == r.file
 		&& l.exit_game_message == r.exit_game_message
 		&& l.yes == r.yes
-		&& l.no == r.no;
+		&& l.no == r.no
+		&& l.easyrpg_item_number_separator == r.easyrpg_item_number_separator
+		&& l.easyrpg_skill_cost_separator == r.easyrpg_skill_cost_separator
+		&& l.easyrpg_equipment_arrow == r.easyrpg_equipment_arrow
+		&& l.easyrpg_status_scene_name == r.easyrpg_status_scene_name
+		&& l.easyrpg_status_scene_class == r.easyrpg_status_scene_class
+		&& l.easyrpg_status_scene_title == r.easyrpg_status_scene_title
+		&& l.easyrpg_status_scene_condition == r.easyrpg_status_scene_condition
+		&& l.easyrpg_status_scene_front == r.easyrpg_status_scene_front
+		&& l.easyrpg_status_scene_back == r.easyrpg_status_scene_back
+		&& l.easyrpg_order_scene_confirm == r.easyrpg_order_scene_confirm
+		&& l.easyrpg_order_scene_redo == r.easyrpg_order_scene_redo
+		&& l.easyrpg_battle2k3_double_attack == r.easyrpg_battle2k3_double_attack
+		&& l.easyrpg_battle2k3_defend == r.easyrpg_battle2k3_defend
+		&& l.easyrpg_battle2k3_observe == r.easyrpg_battle2k3_observe
+		&& l.easyrpg_battle2k3_charge == r.easyrpg_battle2k3_charge
+		&& l.easyrpg_battle2k3_selfdestruct == r.easyrpg_battle2k3_selfdestruct
+		&& l.easyrpg_battle2k3_escape == r.easyrpg_battle2k3_escape
+		&& l.easyrpg_battle2k3_special_combat_back == r.easyrpg_battle2k3_special_combat_back;
 	}
 
 	inline bool operator!=(const Terms& l, const Terms& r) {
@@ -546,6 +585,42 @@ namespace rpg {
 		f(obj.yes, ctx126);
 		const auto ctx127 = Context<Terms, ParentCtx>{ "no", -1, &obj, parent_ctx };
 		f(obj.no, ctx127);
+		const auto ctx128 = Context<Terms, ParentCtx>{ "easyrpg_item_number_separator", -1, &obj, parent_ctx };
+		f(obj.easyrpg_item_number_separator, ctx128);
+		const auto ctx129 = Context<Terms, ParentCtx>{ "easyrpg_skill_cost_separator", -1, &obj, parent_ctx };
+		f(obj.easyrpg_skill_cost_separator, ctx129);
+		const auto ctx130 = Context<Terms, ParentCtx>{ "easyrpg_equipment_arrow", -1, &obj, parent_ctx };
+		f(obj.easyrpg_equipment_arrow, ctx130);
+		const auto ctx131 = Context<Terms, ParentCtx>{ "easyrpg_status_scene_name", -1, &obj, parent_ctx };
+		f(obj.easyrpg_status_scene_name, ctx131);
+		const auto ctx132 = Context<Terms, ParentCtx>{ "easyrpg_status_scene_class", -1, &obj, parent_ctx };
+		f(obj.easyrpg_status_scene_class, ctx132);
+		const auto ctx133 = Context<Terms, ParentCtx>{ "easyrpg_status_scene_title", -1, &obj, parent_ctx };
+		f(obj.easyrpg_status_scene_title, ctx133);
+		const auto ctx134 = Context<Terms, ParentCtx>{ "easyrpg_status_scene_condition", -1, &obj, parent_ctx };
+		f(obj.easyrpg_status_scene_condition, ctx134);
+		const auto ctx135 = Context<Terms, ParentCtx>{ "easyrpg_status_scene_front", -1, &obj, parent_ctx };
+		f(obj.easyrpg_status_scene_front, ctx135);
+		const auto ctx136 = Context<Terms, ParentCtx>{ "easyrpg_status_scene_back", -1, &obj, parent_ctx };
+		f(obj.easyrpg_status_scene_back, ctx136);
+		const auto ctx137 = Context<Terms, ParentCtx>{ "easyrpg_order_scene_confirm", -1, &obj, parent_ctx };
+		f(obj.easyrpg_order_scene_confirm, ctx137);
+		const auto ctx138 = Context<Terms, ParentCtx>{ "easyrpg_order_scene_redo", -1, &obj, parent_ctx };
+		f(obj.easyrpg_order_scene_redo, ctx138);
+		const auto ctx139 = Context<Terms, ParentCtx>{ "easyrpg_battle2k3_double_attack", -1, &obj, parent_ctx };
+		f(obj.easyrpg_battle2k3_double_attack, ctx139);
+		const auto ctx140 = Context<Terms, ParentCtx>{ "easyrpg_battle2k3_defend", -1, &obj, parent_ctx };
+		f(obj.easyrpg_battle2k3_defend, ctx140);
+		const auto ctx141 = Context<Terms, ParentCtx>{ "easyrpg_battle2k3_observe", -1, &obj, parent_ctx };
+		f(obj.easyrpg_battle2k3_observe, ctx141);
+		const auto ctx142 = Context<Terms, ParentCtx>{ "easyrpg_battle2k3_charge", -1, &obj, parent_ctx };
+		f(obj.easyrpg_battle2k3_charge, ctx142);
+		const auto ctx143 = Context<Terms, ParentCtx>{ "easyrpg_battle2k3_selfdestruct", -1, &obj, parent_ctx };
+		f(obj.easyrpg_battle2k3_selfdestruct, ctx143);
+		const auto ctx144 = Context<Terms, ParentCtx>{ "easyrpg_battle2k3_escape", -1, &obj, parent_ctx };
+		f(obj.easyrpg_battle2k3_escape, ctx144);
+		const auto ctx145 = Context<Terms, ParentCtx>{ "easyrpg_battle2k3_special_combat_back", -1, &obj, parent_ctx };
+		f(obj.easyrpg_battle2k3_special_combat_back, ctx145);
 		(void)obj;
 		(void)f;
 		(void)parent_ctx;

--- a/src/generated/lcf/rpg/terms.h
+++ b/src/generated/lcf/rpg/terms.h
@@ -28,6 +28,7 @@ namespace rpg {
 		// Sentinel name used to denote that the default hardcoded term should be used.
 		static constexpr const char* kDefaultTerm = "default_term";
 
+		static std::string TermOrDefault(const DBString& db_term, StringView default_term);
 		DBString encounter;
 		DBString special_combat;
 		DBString escape_success;

--- a/src/generated/ldb_terms.cpp
+++ b/src/generated/ldb_terms.cpp
@@ -909,6 +909,132 @@ static TypedField<rpg::Terms, DBString> static_no(
 	1,
 	0
 );
+static TypedField<rpg::Terms, DBString> static_easyrpg_item_number_separator(
+	&rpg::Terms::easyrpg_item_number_separator,
+	LDB_Reader::ChunkTerms::easyrpg_item_number_separator,
+	"easyrpg_item_number_separator",
+	0,
+	0
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_skill_cost_separator(
+	&rpg::Terms::easyrpg_skill_cost_separator,
+	LDB_Reader::ChunkTerms::easyrpg_skill_cost_separator,
+	"easyrpg_skill_cost_separator",
+	0,
+	0
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_equipment_arrow(
+	&rpg::Terms::easyrpg_equipment_arrow,
+	LDB_Reader::ChunkTerms::easyrpg_equipment_arrow,
+	"easyrpg_equipment_arrow",
+	0,
+	0
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_status_scene_name(
+	&rpg::Terms::easyrpg_status_scene_name,
+	LDB_Reader::ChunkTerms::easyrpg_status_scene_name,
+	"easyrpg_status_scene_name",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_status_scene_class(
+	&rpg::Terms::easyrpg_status_scene_class,
+	LDB_Reader::ChunkTerms::easyrpg_status_scene_class,
+	"easyrpg_status_scene_class",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_status_scene_title(
+	&rpg::Terms::easyrpg_status_scene_title,
+	LDB_Reader::ChunkTerms::easyrpg_status_scene_title,
+	"easyrpg_status_scene_title",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_status_scene_condition(
+	&rpg::Terms::easyrpg_status_scene_condition,
+	LDB_Reader::ChunkTerms::easyrpg_status_scene_condition,
+	"easyrpg_status_scene_condition",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_status_scene_front(
+	&rpg::Terms::easyrpg_status_scene_front,
+	LDB_Reader::ChunkTerms::easyrpg_status_scene_front,
+	"easyrpg_status_scene_front",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_status_scene_back(
+	&rpg::Terms::easyrpg_status_scene_back,
+	LDB_Reader::ChunkTerms::easyrpg_status_scene_back,
+	"easyrpg_status_scene_back",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_order_scene_confirm(
+	&rpg::Terms::easyrpg_order_scene_confirm,
+	LDB_Reader::ChunkTerms::easyrpg_order_scene_confirm,
+	"easyrpg_order_scene_confirm",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_order_scene_redo(
+	&rpg::Terms::easyrpg_order_scene_redo,
+	LDB_Reader::ChunkTerms::easyrpg_order_scene_redo,
+	"easyrpg_order_scene_redo",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_battle2k3_double_attack(
+	&rpg::Terms::easyrpg_battle2k3_double_attack,
+	LDB_Reader::ChunkTerms::easyrpg_battle2k3_double_attack,
+	"easyrpg_battle2k3_double_attack",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_battle2k3_defend(
+	&rpg::Terms::easyrpg_battle2k3_defend,
+	LDB_Reader::ChunkTerms::easyrpg_battle2k3_defend,
+	"easyrpg_battle2k3_defend",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_battle2k3_observe(
+	&rpg::Terms::easyrpg_battle2k3_observe,
+	LDB_Reader::ChunkTerms::easyrpg_battle2k3_observe,
+	"easyrpg_battle2k3_observe",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_battle2k3_charge(
+	&rpg::Terms::easyrpg_battle2k3_charge,
+	LDB_Reader::ChunkTerms::easyrpg_battle2k3_charge,
+	"easyrpg_battle2k3_charge",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_battle2k3_selfdestruct(
+	&rpg::Terms::easyrpg_battle2k3_selfdestruct,
+	LDB_Reader::ChunkTerms::easyrpg_battle2k3_selfdestruct,
+	"easyrpg_battle2k3_selfdestruct",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_battle2k3_escape(
+	&rpg::Terms::easyrpg_battle2k3_escape,
+	LDB_Reader::ChunkTerms::easyrpg_battle2k3_escape,
+	"easyrpg_battle2k3_escape",
+	0,
+	1
+);
+static TypedField<rpg::Terms, DBString> static_easyrpg_battle2k3_special_combat_back(
+	&rpg::Terms::easyrpg_battle2k3_special_combat_back,
+	LDB_Reader::ChunkTerms::easyrpg_battle2k3_special_combat_back,
+	"easyrpg_battle2k3_special_combat_back",
+	0,
+	1
+);
 
 
 template <>
@@ -1040,6 +1166,24 @@ Field<rpg::Terms> const* Struct<rpg::Terms>::fields[] = {
 	&static_exit_game_message,
 	&static_yes,
 	&static_no,
+	&static_easyrpg_item_number_separator,
+	&static_easyrpg_skill_cost_separator,
+	&static_easyrpg_equipment_arrow,
+	&static_easyrpg_status_scene_name,
+	&static_easyrpg_status_scene_class,
+	&static_easyrpg_status_scene_title,
+	&static_easyrpg_status_scene_condition,
+	&static_easyrpg_status_scene_front,
+	&static_easyrpg_status_scene_back,
+	&static_easyrpg_order_scene_confirm,
+	&static_easyrpg_order_scene_redo,
+	&static_easyrpg_battle2k3_double_attack,
+	&static_easyrpg_battle2k3_defend,
+	&static_easyrpg_battle2k3_observe,
+	&static_easyrpg_battle2k3_charge,
+	&static_easyrpg_battle2k3_selfdestruct,
+	&static_easyrpg_battle2k3_escape,
+	&static_easyrpg_battle2k3_special_combat_back,
 	NULL
 };
 

--- a/src/generated/rpg_terms.cpp
+++ b/src/generated/rpg_terms.cpp
@@ -12,6 +12,7 @@
 // Headers
 #include "lcf/rpg/terms.h"
 
+constexpr const char* lcf::rpg::Terms::kDefaultTerm;
 namespace lcf {
 namespace rpg {
 
@@ -144,6 +145,24 @@ std::ostream& operator<<(std::ostream& os, const Terms& obj) {
 	os << ", exit_game_message="<< obj.exit_game_message;
 	os << ", yes="<< obj.yes;
 	os << ", no="<< obj.no;
+	os << ", easyrpg_item_number_separator="<< obj.easyrpg_item_number_separator;
+	os << ", easyrpg_skill_cost_separator="<< obj.easyrpg_skill_cost_separator;
+	os << ", easyrpg_equipment_arrow="<< obj.easyrpg_equipment_arrow;
+	os << ", easyrpg_status_scene_name="<< obj.easyrpg_status_scene_name;
+	os << ", easyrpg_status_scene_class="<< obj.easyrpg_status_scene_class;
+	os << ", easyrpg_status_scene_title="<< obj.easyrpg_status_scene_title;
+	os << ", easyrpg_status_scene_condition="<< obj.easyrpg_status_scene_condition;
+	os << ", easyrpg_status_scene_front="<< obj.easyrpg_status_scene_front;
+	os << ", easyrpg_status_scene_back="<< obj.easyrpg_status_scene_back;
+	os << ", easyrpg_order_scene_confirm="<< obj.easyrpg_order_scene_confirm;
+	os << ", easyrpg_order_scene_redo="<< obj.easyrpg_order_scene_redo;
+	os << ", easyrpg_battle2k3_double_attack="<< obj.easyrpg_battle2k3_double_attack;
+	os << ", easyrpg_battle2k3_defend="<< obj.easyrpg_battle2k3_defend;
+	os << ", easyrpg_battle2k3_observe="<< obj.easyrpg_battle2k3_observe;
+	os << ", easyrpg_battle2k3_charge="<< obj.easyrpg_battle2k3_charge;
+	os << ", easyrpg_battle2k3_selfdestruct="<< obj.easyrpg_battle2k3_selfdestruct;
+	os << ", easyrpg_battle2k3_escape="<< obj.easyrpg_battle2k3_escape;
+	os << ", easyrpg_battle2k3_special_combat_back="<< obj.easyrpg_battle2k3_special_combat_back;
 	os << "}";
 	return os;
 }

--- a/src/rpg_terms.cpp
+++ b/src/rpg_terms.cpp
@@ -1,0 +1,21 @@
+/*
+ * This file is part of liblcf. Copyright (c) 2020 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+#include "lcf/rpg/terms.h"
+
+namespace lcf {
+
+std::string rpg::Terms::TermOrDefault(const DBString& db_term, StringView default_term) {
+	if (db_term == kDefaultTerm) {
+		return ToString(default_term);
+	}
+	return ToString(db_term);
+}
+
+} // namespace lcf


### PR DESCRIPTION
This PR adds the following database settings:
- Term 200: Item number separator
- Term 201: Skill cost separator
- Term 202: Equipment window arrow
- Term 203: Status scene Name
- Term 204: Status scene Class
- Term 205: Status scene Title
- Term 206: Status scene Condition
- Term 207: Status scene Front
- Term 208: Status scene Back
- Term 209: Order scene Confirm
- Term 210: Order scene Redo
- Term 211: RPG Maker 2003 battle monster Double Attack notification
- Term 212: RPG Maker 2003 battle monster Defend notification
- Term 213: RPG Maker 2003 battle monster Observe notification
- Term 214: RPG Maker 2003 battle monster Charge notification
- Term 215: RPG Maker 2003 battle monster Self-Destruct notification
- Term 216: RPG Maker 2003 battle monster Escape notification
- Term 217: Message for back and pincer attack