### PR TITLE
CMake 3.8: Fix liblcf-config.cmake

### DIFF
--- a/builds/liblcf-config.cmake.in
+++ b/builds/liblcf-config.cmake.in
@@ -117,7 +117,8 @@ if(LIBLCF_FOUND)
 		endif()
 
 		if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.8")
-			target_compile_features(liblcf::liblcf INTERFACE cxx_std_14)
+			set_property(TARGET liblcf::liblcf APPEND PROPERTY
+				COMPILE_FEATURES cxx_std_14)
 		endif()
 
 		mark_as_advanced(LIBLCF_LIBRARY_DEPS LIBLCF_LINK_LIBRARIES)


### PR DESCRIPTION
Detected by Android because it forces me to use this version... 