### PR TITLE
Allow redirection of lcf console messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,9 @@ set(LCF_SOURCES
 	src/lmt_treemap.cpp
 	src/lmu_movecommand.cpp
 	src/lmu_reader.cpp
+	src/log.h
 	src/lsd_reader.cpp
+	src/log_handler.cpp
 	src/reader_flags.cpp
 	src/reader_lcf.cpp
 	src/reader_struct.h
@@ -208,6 +210,7 @@ set(LCF_HEADERS
 	src/lcf/lmt/reader.h
 	src/lcf/lmu/reader.h
 	src/lcf/lsd/reader.h
+	src/lcf/log_handler.h
 	src/lcf/reader_lcf.h
 	src/lcf/reader_util.h
 	src/lcf/reader_xml.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,9 @@ liblcf_la_SOURCES = \
 	src/lmt_treemap.cpp \
 	src/lmu_movecommand.cpp \
 	src/lmu_reader.cpp \
+	src/log.h \
 	src/lsd_reader.cpp \
+	src/log_handler.cpp \
 	src/reader_flags.cpp \
 	src/reader_lcf.cpp \
 	src/reader_struct.h \
@@ -219,6 +221,7 @@ lcfinclude_HEADERS = \
 	src/lcf/flag_set.h \
 	src/lcf/ini.h \
 	src/lcf/inireader.h \
+	src/lcf/log_handler.h \
 	src/lcf/reader_lcf.h \
 	src/lcf/reader_util.h \
 	src/lcf/reader_xml.h \

--- a/src/dbstring_struct.cpp
+++ b/src/dbstring_struct.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "lcf/dbstring.h"
+#include "log.h"
 #include "reader_struct.h"
 #include <iostream>
 
@@ -43,7 +44,7 @@ struct RawStruct<std::vector<DBString> > {
 void RawStruct<DBString>::ReadLcf(DBString& ref, LcfReader& stream, uint32_t length) {
 	stream.ReadString(ref, length);
 #ifdef LCF_DEBUG_TRACE
-	printf("  %s\n", ref.c_str());
+	fprintf(stderr, "  %s\n", ref.c_str());
 #endif
 }
 
@@ -106,9 +107,7 @@ void RawStruct<std::vector<DBString>>::ReadLcf(std::vector<DBString>& ref, LcfRe
 	}
 
 	if (stream.Tell() != endpos) {
-#ifdef LCF_DEBUG_TRACE
-		fprintf(stderr, "Misaligned!\n");
-#endif
+		Log::Warning("vector<string> Misaligned at 0x" PRIx32 "", stream.Tell());
 		stream.Seek(endpos);
 	}
 }
@@ -177,7 +176,7 @@ public:
 
 	void StartElement(XmlReader& stream, const char* name, const char** atts) {
 		if (strcmp(name, "item") != 0) {
-			stream.Error("Expecting %s but got %s", "item", name);
+			Log::Error("XML: Expecting %s but got %s", "item", name);
 			return;
 		}
 
@@ -191,7 +190,7 @@ public:
 		}
 
 		if (id <= last_id || id < -1) {
-			stream.Error("Bad Id %d / %d", id, last_id);
+			Log::Error("XML: Bad Id %d / %d", id, last_id);
 			return;
 		}
 

--- a/src/dbstring_struct.cpp
+++ b/src/dbstring_struct.cpp
@@ -107,7 +107,7 @@ void RawStruct<std::vector<DBString>>::ReadLcf(std::vector<DBString>& ref, LcfRe
 	}
 
 	if (stream.Tell() != endpos) {
-		Log::Warning("vector<string> Misaligned at 0x" PRIx32 "", stream.Tell());
+		Log::Warning("vector<string> Misaligned at 0x%" PRIx32 "", stream.Tell());
 		stream.Seek(endpos);
 	}
 }

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -10,6 +10,7 @@
 #include "lcf/encoder.h"
 #include "lcf/reader_util.h"
 #include "lcf/scope_guard.h"
+#include "log.h"
 #include <cstdio>
 #include <cstdlib>
 
@@ -86,7 +87,7 @@ void Encoder::Init() {
 	auto conv_runtime = ucnv_open(runtime_encoding, &status);
 
 	if (conv_runtime == nullptr) {
-		fprintf(stderr, "liblcf:  ucnv_open() error for encoding \"%s\": %s\n", runtime_encoding, u_errorName(status));
+		Log::Error("ucnv_open() error for encoding \"%s\": %s", runtime_encoding, u_errorName(status));
 		return;
 	}
 	status = U_ZERO_ERROR;
@@ -95,7 +96,7 @@ void Encoder::Init() {
 	auto conv_storage = ucnv_open(storage_encoding.c_str(), &status);
 
 	if (conv_storage == nullptr) {
-		fprintf(stderr, "liblcf:  ucnv_open() error for dest encoding \"%s\": %s\n", storage_encoding.c_str(), u_errorName(status));
+		Log::Error("ucnv_open() error for dest encoding \"%s\": %s", storage_encoding.c_str(), u_errorName(status));
 		return;
 	}
 
@@ -143,7 +144,7 @@ void Encoder::Convert(std::string& str, UConverter* conv_dst, UConverter* conv_s
 			&status);
 
 	if (U_FAILURE(status)) {
-		fprintf(stderr, "liblcf: ucnv_convertEx() error when encoding \"%s\": %s\n", src.c_str(), u_errorName(status));
+		Log::Error("ucnv_convertEx() error when encoding \"%s\": %s", src.c_str(), u_errorName(status));
 		_buffer.clear();
 	}
 

--- a/src/lcf/log_handler.h
+++ b/src/lcf/log_handler.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of liblcf. Copyright (c) 2020 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+#ifndef LCF_OUTPUT_H
+#define LCF_OUTPUT_H
+
+#include "string_view.h"
+
+namespace lcf {
+namespace LogHandler {
+
+enum class Level {
+	Debug,
+	Warning,
+	Error,
+	Highest
+};
+
+using LogHandlerFn = void (*)(Level level, StringView message);
+
+/**
+ * Sets the output handler for all lcf logging.
+ * The default handler prints to standard error.
+ *
+ * @param fn New output handler. nullptr for default handler.
+ */
+void SetHandler(LogHandlerFn fn);
+
+/**
+ * Only report issues that have at least this log level.
+ * Use Highest to disable logging.
+ * Default: Debug
+ *
+ * @param new_level New log level
+ */
+void SetLevel(Level new_level);
+
+} // namespace LogHandler
+} // namespace lcf
+
+#endif

--- a/src/lcf/log_handler.h
+++ b/src/lcf/log_handler.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of liblcf. Copyright (c) 2020 liblcf authors.
+ * This file is part of liblcf. Copyright (c) liblcf authors.
  * https://github.com/EasyRPG/liblcf - https://easyrpg.org
  *
  * liblcf is Free/Libre Open Source Software, released under the MIT License.

--- a/src/lcf/log_handler.h
+++ b/src/lcf/log_handler.h
@@ -11,6 +11,7 @@
 #define LCF_OUTPUT_H
 
 #include "string_view.h"
+#include "enum_tags.h"
 
 namespace lcf {
 namespace LogHandler {
@@ -22,15 +23,24 @@ enum class Level {
 	Highest
 };
 
-using LogHandlerFn = void (*)(Level level, StringView message);
+static constexpr auto kLevelTags = lcf::makeEnumTags<Level>(
+	"Debug",
+	"Warning",
+	"Error",
+	"Highest"
+);
+
+using UserData = void*;
+using LogHandlerFn = void (*)(Level level, StringView message, UserData userdata);
 
 /**
  * Sets the output handler for all lcf logging.
  * The default handler prints to standard error.
  *
  * @param fn New output handler. nullptr for default handler.
+ * @param userdata Passed to the log handler function. Is not touched by liblcf.
  */
-void SetHandler(LogHandlerFn fn);
+void SetHandler(LogHandlerFn fn, UserData userdata = nullptr);
 
 /**
  * Only report issues that have at least this log level.

--- a/src/lcf/reader_xml.h
+++ b/src/lcf/reader_xml.h
@@ -55,11 +55,6 @@ public:
 	bool IsOk() const;
 
 	/**
-	 * Reports a parsing error.
-	 */
-	void Error(const char* fmt, ...);
-
-	/**
 	 * Parses the XML file.
 	 */
 	void Parse();

--- a/src/ldb_equipment.cpp
+++ b/src/ldb_equipment.cpp
@@ -9,6 +9,7 @@
 
 #include "lcf/ldb/reader.h"
 #include "lcf/ldb/chunks.h"
+#include "log.h"
 #include "reader_struct.h"
 
 namespace lcf {
@@ -27,7 +28,7 @@ struct RawStruct<rpg::Equipment> {
  */
 void RawStruct<rpg::Equipment>::ReadLcf(rpg::Equipment& ref, LcfReader& stream, uint32_t length) {
 	if (length != 10) {
-		fprintf(stderr, "Equipment has incorrect size %" PRIu32 " (expected 10)\n", length);
+		Log::Warning("Equipment has incorrect size %" PRIu32 " (expected 10)", length);
 
 		LcfReader::Chunk chunk_info;
 		chunk_info.ID = 0x33;
@@ -85,7 +86,7 @@ public:
 		else if (strcmp(name, "accessory_id") == 0)
 			field = &ref.accessory_id;
 		else {
-			stream.Error("Unrecognized field '%s'", name);
+			Log::Error("XML: Unrecognized field '%s'", name);
 			field = NULL;
 		}
 	}

--- a/src/ldb_eventcommand.cpp
+++ b/src/ldb_eventcommand.cpp
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include "log.h"
 #include "reader_struct.h"
 #include "lcf/rpg/eventcommand.h"
 
@@ -108,7 +109,7 @@ public:
 		else if (strcmp(name, "parameters") == 0)
 			field = Parameters;
 		else {
-			stream.Error("Unrecognized field '%s'", name);
+			Log::Error("XML: Unrecognized field '%s'", name);
 			field = None;
 		}
 	}
@@ -161,7 +162,7 @@ void RawStruct<std::vector<rpg::EventCommand> >::ReadLcf(
 
 		if (stream.Tell() >= endpos) {
 			stream.Seek(endpos, LcfReader::FromStart);
-			fprintf(stderr, "Event command corrupted at %" PRIu32 "\n", stream.Tell());
+			Log::Warning("Event command corrupted at %" PRIu32 "", stream.Tell());
 			for (;;) {
 				// Try finding the real end of the event command (4 0-bytes)
 				int i = 0;
@@ -216,7 +217,7 @@ public:
 
 	void StartElement(XmlReader& stream, const char* name, const char** /* atts */) {
 		if (strcmp(name, "EventCommand") != 0)
-			stream.Error("Expecting %s but got %s", "EventCommand", name);
+			Log::Error("XML: Expecting %s but got %s", "EventCommand", name);
 		ref.resize(ref.size() + 1);
 		rpg::EventCommand& obj = ref.back();
 		stream.SetHandler(new EventCommandXmlHandler(obj));

--- a/src/ldb_parameters.cpp
+++ b/src/ldb_parameters.cpp
@@ -79,7 +79,7 @@ public:
 		else if (strcmp(name, "agility") == 0)
 			field = &ref.agility;
 		else {
-			stream.Error("Unrecognized field '%s'", name);
+			Log::Error("XML: Unrecognized field '%s'", name);
 			field = NULL;
 		}
 	}

--- a/src/ldb_reader.cpp
+++ b/src/ldb_reader.cpp
@@ -14,6 +14,7 @@
 #include "lcf/ldb/reader.h"
 #include "lcf/ldb/chunks.h"
 #include "lcf/reader_util.h"
+#include "log.h"
 #include "reader_struct.h"
 
 namespace lcf {
@@ -25,7 +26,7 @@ void LDB_Reader::PrepareSave(rpg::Database& db) {
 std::unique_ptr<lcf::rpg::Database> LDB_Reader::Load(StringView filename, StringView encoding) {
 	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LDB file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LDB file '%s' for reading: %s", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LDB_Reader::Load(stream, encoding);
@@ -34,7 +35,7 @@ std::unique_ptr<lcf::rpg::Database> LDB_Reader::Load(StringView filename, String
 bool LDB_Reader::Save(StringView filename, const lcf::rpg::Database& db, StringView encoding, SaveOpt opt) {
 	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LDB file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LDB file '%s' for writing: %s", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LDB_Reader::Save(stream, db, encoding, opt);
@@ -43,7 +44,7 @@ bool LDB_Reader::Save(StringView filename, const lcf::rpg::Database& db, StringV
 bool LDB_Reader::SaveXml(StringView filename, const lcf::rpg::Database& db) {
 	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LDB XML file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LDB XML file '%s' for writing: %s", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LDB_Reader::SaveXml(stream, db);
@@ -52,7 +53,7 @@ bool LDB_Reader::SaveXml(StringView filename, const lcf::rpg::Database& db) {
 std::unique_ptr<lcf::rpg::Database> LDB_Reader::LoadXml(StringView filename) {
 	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LDB XML file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LDB XML file '%s' for reading: %s", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LDB_Reader::LoadXml(stream);
@@ -61,17 +62,17 @@ std::unique_ptr<lcf::rpg::Database> LDB_Reader::LoadXml(StringView filename) {
 std::unique_ptr<lcf::rpg::Database> LDB_Reader::Load(std::istream& filestream, StringView encoding) {
 	LcfReader reader(filestream, ToString(encoding));
 	if (!reader.IsOk()) {
-		LcfReader::SetError("Couldn't parse database file.\n");
+		LcfReader::SetError("Couldn't parse database file.");
 		return nullptr;
 	}
 	std::string header;
 	reader.ReadString(header, reader.ReadInt());
 	if (header.length() != 11) {
-		LcfReader::SetError("This is not a valid RPG2000 database.\n");
+		LcfReader::SetError("This is not a valid RPG2000 database.");
 		return nullptr;
 	}
 	if (header != "LcfDataBase") {
-		fprintf(stderr, "Warning: This header is not LcfDataBase and might not be a valid RPG2000 database.\n");
+		Log::Warning("Header %s != LcfDataBase and might not be a valid RPG2000 database.", header.c_str());
 	}
 	auto db = std::make_unique<lcf::rpg::Database>();
 	db->ldb_header = header;
@@ -91,7 +92,7 @@ bool LDB_Reader::Save(std::ostream& filestream, const lcf::rpg::Database& db, St
 	const auto engine = GetEngineVersion(db);
 	LcfWriter writer(filestream, engine, ToString(encoding));
 	if (!writer.IsOk()) {
-		LcfReader::SetError("Couldn't parse database file.\n");
+		LcfReader::SetError("Couldn't parse database file.");
 		return false;
 	}
 	std::string header;

--- a/src/lmt_reader.cpp
+++ b/src/lmt_reader.cpp
@@ -14,6 +14,7 @@
 #include "lcf/lmt/reader.h"
 #include "lcf/lmt/chunks.h"
 #include "lcf/reader_util.h"
+#include "log.h"
 #include "reader_struct.h"
 
 namespace lcf {
@@ -21,7 +22,7 @@ namespace lcf {
 std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::Load(StringView filename, StringView encoding) {
 	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMT file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LMT file '%s' for reading: %s", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LMT_Reader::Load(stream, encoding);
@@ -30,7 +31,7 @@ std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::Load(StringView filename, StringV
 bool LMT_Reader::Save(StringView filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine, StringView encoding, SaveOpt opt) {
 	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMT file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LMT file '%s' for writing: %s", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LMT_Reader::Save(stream, tmap, engine, encoding, opt);
@@ -39,7 +40,7 @@ bool LMT_Reader::Save(StringView filename, const lcf::rpg::TreeMap& tmap, Engine
 bool LMT_Reader::SaveXml(StringView filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine) {
 	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMT XML file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LMT XML file '%s' for writing: %s", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LMT_Reader::SaveXml(stream, tmap, engine);
@@ -48,7 +49,7 @@ bool LMT_Reader::SaveXml(StringView filename, const lcf::rpg::TreeMap& tmap, Eng
 std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::LoadXml(StringView filename) {
 	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMT XML file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LMT XML file '%s' for reading: %s", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LMT_Reader::LoadXml(stream);
@@ -57,17 +58,17 @@ std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::LoadXml(StringView filename) {
 std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::Load(std::istream& filestream, StringView encoding) {
 	LcfReader reader(filestream, ToString(encoding));
 	if (!reader.IsOk()) {
-		LcfReader::SetError("Couldn't parse map tree file.\n");
+		LcfReader::SetError("Couldn't parse map tree file.");
 		return nullptr;
 	}
 	std::string header;
 	reader.ReadString(header, reader.ReadInt());
 	if (header.length() != 10) {
-		LcfReader::SetError("This is not a valid RPG2000 map tree.\n");
+		LcfReader::SetError("This is not a valid RPG2000 map tree.");
 		return nullptr;
 	}
 	if (header != "LcfMapTree") {
-		fprintf(stderr, "Warning: This header is not LcfMapTree and might not be a valid RPG2000 map tree.\n");
+		Log::Warning("Header %s != LcfMapTree and might not be a valid RPG2000 map tree.", header.c_str());
 	}
 	auto tmap = std::make_unique<lcf::rpg::TreeMap>();
 	tmap->lmt_header = std::move(header);
@@ -78,7 +79,7 @@ std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::Load(std::istream& filestream, St
 bool LMT_Reader::Save(std::ostream& filestream, const lcf::rpg::TreeMap& tmap, EngineVersion engine, StringView encoding, SaveOpt opt) {
 	LcfWriter writer(filestream, engine, ToString(encoding));
 	if (!writer.IsOk()) {
-		LcfReader::SetError("Couldn't parse map tree file.\n");
+		LcfReader::SetError("Couldn't parse map tree file.");
 		return false;
 	}
 	std::string header;
@@ -96,7 +97,7 @@ bool LMT_Reader::Save(std::ostream& filestream, const lcf::rpg::TreeMap& tmap, E
 bool LMT_Reader::SaveXml(std::ostream& filestream, const lcf::rpg::TreeMap& tmap, EngineVersion engine) {
 	XmlWriter writer(filestream, engine);
 	if (!writer.IsOk()) {
-		LcfReader::SetError("Couldn't parse map tree file.\n");
+		LcfReader::SetError("Couldn't parse map tree file.");
 		return false;
 	}
 	writer.BeginElement("LMT");
@@ -108,7 +109,7 @@ bool LMT_Reader::SaveXml(std::ostream& filestream, const lcf::rpg::TreeMap& tmap
 std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::LoadXml(std::istream& filestream) {
 	XmlReader reader(filestream);
 	if (!reader.IsOk()) {
-		LcfReader::SetError("Couldn't parse map tree file.\n");
+		LcfReader::SetError("Couldn't parse map tree file.");
 		return nullptr;
 	}
 	auto tmap = std::make_unique<lcf::rpg::TreeMap>();

--- a/src/lmt_rect.cpp
+++ b/src/lmt_rect.cpp
@@ -70,7 +70,7 @@ public:
 		else if (strcmp(name, "b") == 0)
 			field = &ref.b;
 		else {
-			stream.Error("Unrecognized field '%s'", name);
+			Log::Error("XML: Unrecognized field '%s'", name);
 			field = NULL;
 		}
 	}

--- a/src/lmt_treemap.cpp
+++ b/src/lmt_treemap.cpp
@@ -9,6 +9,7 @@
 
 #include "lcf/lmt/reader.h"
 #include "lcf/lmt/chunks.h"
+#include "log.h"
 #include "reader_struct.h"
 
 namespace lcf {
@@ -89,7 +90,7 @@ public:
 		else if (strcmp(name, "start") == 0)
 			Struct<rpg::Start>::BeginXml(ref.start, stream);
 		else {
-			stream.Error("Unrecognized field '%s'", name);
+			Log::Error("XML: Unrecognized field '%s'", name);
 		}
 	}
 	void EndElement(XmlReader& /* stream */, const char* /* name */) {

--- a/src/lmu_movecommand.cpp
+++ b/src/lmu_movecommand.cpp
@@ -158,7 +158,7 @@ public:
 		else if (strcmp(name, "parameter_string") == 0)
 			parameter_string = true;
 		else {
-			stream.Error("Unrecognized field '%s'", name);
+			Log::Error("XML: Unrecognized field '%s'", name);
 			field = NULL;
 			parameter_string = false;
 		}
@@ -218,7 +218,7 @@ public:
 
 	void StartElement(XmlReader& stream, const char* name, const char** /* atts */) {
 		if (strcmp(name, "MoveCommand") != 0)
-			stream.Error("Expecting %s but got %s", "MoveCommand", name);
+			Log::Error("XML: Expecting %s but got %s", "MoveCommand", name);
 		ref.resize(ref.size() + 1);
 		rpg::MoveCommand& obj = ref.back();
 		stream.SetHandler(new MoveCommandXmlHandler(obj));

--- a/src/lmu_reader.cpp
+++ b/src/lmu_reader.cpp
@@ -16,6 +16,7 @@
 #include "lcf/lmu/chunks.h"
 #include "lcf/reader_lcf.h"
 #include "lcf/reader_util.h"
+#include "log.h"
 #include "reader_struct.h"
 
 namespace lcf {
@@ -27,7 +28,7 @@ void LMU_Reader::PrepareSave(rpg::Map& map) {
 std::unique_ptr<rpg::Map> LMU_Reader::Load(StringView filename, StringView encoding) {
 	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMU file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LMU file '%s' for reading: %s", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LMU_Reader::Load(stream, encoding);
@@ -36,7 +37,7 @@ std::unique_ptr<rpg::Map> LMU_Reader::Load(StringView filename, StringView encod
 bool LMU_Reader::Save(StringView filename, const rpg::Map& save, EngineVersion engine, StringView encoding, SaveOpt opt) {
 	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMU file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LMU file '%s' for writing: %s", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LMU_Reader::Save(stream, save, engine, encoding, opt);
@@ -45,7 +46,7 @@ bool LMU_Reader::Save(StringView filename, const rpg::Map& save, EngineVersion e
 bool LMU_Reader::SaveXml(StringView filename, const rpg::Map& save, EngineVersion engine) {
 	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMU XML file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LMU XML file '%s' for writing: %s", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LMU_Reader::SaveXml(stream, save, engine);
@@ -54,7 +55,7 @@ bool LMU_Reader::SaveXml(StringView filename, const rpg::Map& save, EngineVersio
 std::unique_ptr<rpg::Map> LMU_Reader::LoadXml(StringView filename) {
 	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMU XML file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LMU XML file '%s' for reading: %s", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LMU_Reader::LoadXml(stream);
@@ -63,17 +64,17 @@ std::unique_ptr<rpg::Map> LMU_Reader::LoadXml(StringView filename) {
 std::unique_ptr<rpg::Map> LMU_Reader::Load(std::istream& filestream, StringView encoding) {
 	LcfReader reader(filestream, ToString(encoding));
 	if (!reader.IsOk()) {
-		LcfReader::SetError("Couldn't parse map file.\n");
-		return std::unique_ptr<rpg::Map>();
+		LcfReader::SetError("Couldn't parse map file.");
+		return {};
 	}
 	std::string header;
 	reader.ReadString(header, reader.ReadInt());
 	if (header.length() != 10) {
-		LcfReader::SetError("This is not a valid RPG2000 map.\n");
-		return std::unique_ptr<rpg::Map>();
+		LcfReader::SetError("This is not a valid RPG2000 map.");
+		return {};
 	}
 	if (header != "LcfMapUnit") {
-		fprintf(stderr, "Warning: This header is not LcfMapUnit and might not be a valid RPG2000 map.\n");
+		Log::Warning("Header %s != LcfMapUnit and might not be a valid RPG2000 map.", header.c_str());
 	}
 
 	auto map = std::make_unique<rpg::Map>();
@@ -85,7 +86,7 @@ std::unique_ptr<rpg::Map> LMU_Reader::Load(std::istream& filestream, StringView 
 bool LMU_Reader::Save(std::ostream& filestream, const rpg::Map& map, EngineVersion engine, StringView encoding, SaveOpt opt) {
 	LcfWriter writer(filestream, engine, ToString(encoding));
 	if (!writer.IsOk()) {
-		LcfReader::SetError("Couldn't parse map file.\n");
+		LcfReader::SetError("Couldn't parse map file.");
 		return false;
 	}
 	std::string header;
@@ -104,7 +105,7 @@ bool LMU_Reader::Save(std::ostream& filestream, const rpg::Map& map, EngineVersi
 bool LMU_Reader::SaveXml(std::ostream& filestream, const rpg::Map& map, EngineVersion engine) {
 	XmlWriter writer(filestream, engine);
 	if (!writer.IsOk()) {
-		LcfReader::SetError("Couldn't parse map file.\n");
+		LcfReader::SetError("Couldn't parse map file.");
 		return false;
 	}
 	writer.BeginElement("LMU");
@@ -116,8 +117,8 @@ bool LMU_Reader::SaveXml(std::ostream& filestream, const rpg::Map& map, EngineVe
 std::unique_ptr<rpg::Map> LMU_Reader::LoadXml(std::istream& filestream) {
 	XmlReader reader(filestream);
 	if (!reader.IsOk()) {
-		LcfReader::SetError("Couldn't parse map file.\n");
-		return std::unique_ptr<rpg::Map>();
+		LcfReader::SetError("Couldn't parse map file.");
+		return {};
 	}
 
 	auto map = std::make_unique<rpg::Map>();

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,24 @@
+/*
+ * This file is part of liblcf. Copyright (c) 2020 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+#ifndef LCF_LOG_H
+#define LCF_LOG_H
+
+#include "lcf/log_handler.h"
+
+namespace lcf {
+namespace Log {
+
+void Debug(const char* fmt, ...);
+void Warning(const char* fmt, ...);
+
+} // namespace Log
+} // namespace lcf
+
+#endif

--- a/src/log.h
+++ b/src/log.h
@@ -17,6 +17,7 @@ namespace Log {
 
 void Debug(const char* fmt, ...);
 void Warning(const char* fmt, ...);
+void Error(const char* fmt, ...);
 
 } // namespace Log
 } // namespace lcf

--- a/src/log.h
+++ b/src/log.h
@@ -12,14 +12,22 @@
 
 #include "lcf/log_handler.h"
 
+#ifdef __GNUG__
+	#define LIKE_PRINTF __attribute__((format(printf, 1, 2)))
+#else
+	#define LIKE_PRINTF
+#endif
+
 namespace lcf {
 namespace Log {
 
-void Debug(const char* fmt, ...);
-void Warning(const char* fmt, ...);
-void Error(const char* fmt, ...);
+void Debug(const char* fmt, ...) LIKE_PRINTF;
+void Warning(const char* fmt, ...) LIKE_PRINTF;
+void Error(const char* fmt, ...) LIKE_PRINTF;
 
 } // namespace Log
 } // namespace lcf
+
+#undef LIKE_PRINTF
 
 #endif

--- a/src/log.h
+++ b/src/log.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of liblcf. Copyright (c) 2020 liblcf authors.
+ * This file is part of liblcf. Copyright (c) liblcf authors.
  * https://github.com/EasyRPG/liblcf - https://easyrpg.org
  *
  * liblcf is Free/Libre Open Source Software, released under the MIT License.

--- a/src/log_handler.cpp
+++ b/src/log_handler.cpp
@@ -1,0 +1,88 @@
+/*
+ * This file is part of liblcf. Copyright (c) 2020 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+#include "lcf/log_handler.h"
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+#include <iostream>
+
+namespace lcf {
+namespace LogHandler {
+namespace {
+	void DefaultHandler(lcf::LogHandler::Level level, StringView message) {
+		switch (level) {
+			case Level::Debug:
+				std::cerr << "Debug: ";
+				break;
+			case Level::Warning:
+				std::cerr << "Warning: ";
+				break;
+			case Level::Error:
+				std::cerr << "Error: ";
+				break;
+			default:
+				assert(false && "Invalid Log Level");
+		}
+		std::cerr << message << "\n";
+	}
+
+	Level level = Level::Debug;
+	LogHandlerFn output_fn = DefaultHandler;
+}
+
+void SetHandler(LogHandlerFn fn) {
+	if (!fn) {
+		output_fn = DefaultHandler;
+	} else {
+		output_fn = fn;
+	}
+}
+
+void SetLevel(Level new_level) {
+	level = new_level;
+}
+
+} // namespace Output
+
+namespace Log {
+namespace {
+	std::string format_string(char const* fmt, va_list args) {
+		char buf[4096];
+		int const result = vsnprintf(buf, sizeof(buf), fmt, args);
+		if (result < 0) {
+			return std::string();
+		}
+
+		return std::string(buf, static_cast<unsigned int>(result) < sizeof(buf) ? result : sizeof(buf));
+	}
+}
+
+void Debug(const char* fmt, ...) {
+	if (static_cast<int>(LogHandler::Level::Debug) >= static_cast<int>(LogHandler::level)) {
+		va_list args;
+		va_start(args, fmt);
+		auto msg = format_string(fmt, args);
+		LogHandler::output_fn(LogHandler::Level::Debug, msg);
+		va_end(args);
+	}
+}
+
+void Warning(const char* fmt, ...) {
+	if (static_cast<int>(LogHandler::Level::Warning) >= static_cast<int>(LogHandler::level)) {
+		va_list args;
+		va_start(args, fmt);
+		auto msg = format_string(fmt, args);
+		LogHandler::output_fn(LogHandler::Level::Warning, msg);
+		va_end(args);
+	}
+}
+
+} // namespace Log
+} // namespace lcf

--- a/src/log_handler.cpp
+++ b/src/log_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * This file is part of liblcf. Copyright (c) 2020 liblcf authors.
+ * This file is part of liblcf. Copyright (c) liblcf authors.
  * https://github.com/EasyRPG/liblcf - https://easyrpg.org
  *
  * liblcf is Free/Libre Open Source Software, released under the MIT License.

--- a/src/log_handler.cpp
+++ b/src/log_handler.cpp
@@ -57,7 +57,7 @@ namespace {
 		char buf[4096];
 		int const result = vsnprintf(buf, sizeof(buf), fmt, args);
 		if (result < 0) {
-			return std::string();
+			return {};
 		}
 
 		return std::string(buf, static_cast<unsigned int>(result) < sizeof(buf) ? result : sizeof(buf));
@@ -80,6 +80,16 @@ void Warning(const char* fmt, ...) {
 		va_start(args, fmt);
 		auto msg = format_string(fmt, args);
 		LogHandler::output_fn(LogHandler::Level::Warning, msg);
+		va_end(args);
+	}
+}
+
+void Error(const char* fmt, ...) {
+	if (static_cast<int>(LogHandler::Level::Error) >= static_cast<int>(LogHandler::level)) {
+		va_list args;
+		va_start(args, fmt);
+		auto msg = format_string(fmt, args);
+		LogHandler::output_fn(LogHandler::Level::Error, msg);
 		va_end(args);
 	}
 }

--- a/src/log_handler.cpp
+++ b/src/log_handler.cpp
@@ -16,7 +16,7 @@
 namespace lcf {
 namespace LogHandler {
 namespace {
-	void DefaultHandler(lcf::LogHandler::Level level, StringView message) {
+	void DefaultHandler(LogHandler::Level level, StringView message, UserData) {
 		switch (level) {
 			case Level::Debug:
 				std::cerr << "Debug: ";
@@ -35,13 +35,16 @@ namespace {
 
 	Level level = Level::Debug;
 	LogHandlerFn output_fn = DefaultHandler;
+	UserData output_userdata = nullptr;
 }
 
-void SetHandler(LogHandlerFn fn) {
+void SetHandler(LogHandlerFn fn, UserData userdata) {
 	if (!fn) {
 		output_fn = DefaultHandler;
+		output_userdata = nullptr;
 	} else {
 		output_fn = fn;
+		output_userdata = userdata;
 	}
 }
 
@@ -60,7 +63,7 @@ namespace {
 			return {};
 		}
 
-		return std::string(buf, static_cast<unsigned int>(result) < sizeof(buf) ? result : sizeof(buf));
+		return {buf, static_cast<unsigned int>(result) < sizeof(buf) ? result : sizeof(buf)};
 	}
 }
 
@@ -69,7 +72,7 @@ void Debug(const char* fmt, ...) {
 		va_list args;
 		va_start(args, fmt);
 		auto msg = format_string(fmt, args);
-		LogHandler::output_fn(LogHandler::Level::Debug, msg);
+		LogHandler::output_fn(LogHandler::Level::Debug, msg, LogHandler::output_userdata);
 		va_end(args);
 	}
 }
@@ -79,7 +82,7 @@ void Warning(const char* fmt, ...) {
 		va_list args;
 		va_start(args, fmt);
 		auto msg = format_string(fmt, args);
-		LogHandler::output_fn(LogHandler::Level::Warning, msg);
+		LogHandler::output_fn(LogHandler::Level::Warning, msg, LogHandler::output_userdata);
 		va_end(args);
 	}
 }
@@ -89,7 +92,7 @@ void Error(const char* fmt, ...) {
 		va_list args;
 		va_start(args, fmt);
 		auto msg = format_string(fmt, args);
-		LogHandler::output_fn(LogHandler::Level::Error, msg);
+		LogHandler::output_fn(LogHandler::Level::Error, msg, LogHandler::output_userdata);
 		va_end(args);
 	}
 }

--- a/src/lsd_reader.cpp
+++ b/src/lsd_reader.cpp
@@ -16,6 +16,7 @@
 #include "lcf/lsd/chunks.h"
 #include "lcf/rpg/save.h"
 #include "lcf/reader_util.h"
+#include "log.h"
 #include "reader_struct.h"
 
 namespace lcf {
@@ -43,7 +44,7 @@ void LSD_Reader::PrepareSave(rpg::Save& save, int32_t version, int32_t codepage)
 std::unique_ptr<rpg::Save> LSD_Reader::Load(StringView filename, StringView encoding) {
 	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LSD file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
+		lcf::Log::Warning("Failed to open LSD file '%s' for reading : %s", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LSD_Reader::Load(stream, encoding);

--- a/src/lsd_reader.cpp
+++ b/src/lsd_reader.cpp
@@ -44,7 +44,7 @@ void LSD_Reader::PrepareSave(rpg::Save& save, int32_t version, int32_t codepage)
 std::unique_ptr<rpg::Save> LSD_Reader::Load(StringView filename, StringView encoding) {
 	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		lcf::Log::Warning("Failed to open LSD file '%s' for reading : %s", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LSD file '%s' for reading: %s", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LSD_Reader::Load(stream, encoding);
@@ -53,7 +53,7 @@ std::unique_ptr<rpg::Save> LSD_Reader::Load(StringView filename, StringView enco
 bool LSD_Reader::Save(StringView filename, const rpg::Save& save, EngineVersion engine, StringView encoding) {
 	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LSD file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LSD file '%s' for reading: %s", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LSD_Reader::Save(stream, save, engine, encoding);
@@ -62,7 +62,7 @@ bool LSD_Reader::Save(StringView filename, const rpg::Save& save, EngineVersion 
 bool LSD_Reader::SaveXml(StringView filename, const rpg::Save& save, EngineVersion engine) {
 	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LSD XML file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LSD XML file '%s' for writing: %s", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LSD_Reader::SaveXml(stream, save, engine);
@@ -71,7 +71,7 @@ bool LSD_Reader::SaveXml(StringView filename, const rpg::Save& save, EngineVersi
 std::unique_ptr<rpg::Save> LSD_Reader::LoadXml(StringView filename) {
 	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LSD XML file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
+		Log::Error("Failed to open LSD XML file `%s' for reading : %s", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LSD_Reader::LoadXml(stream);
@@ -81,17 +81,17 @@ std::unique_ptr<rpg::Save> LSD_Reader::Load(std::istream& filestream, StringView
 	LcfReader reader(filestream, ToString(encoding));
 
 	if (!reader.IsOk()) {
-		LcfReader::SetError("Couldn't parse save file.\n");
-		return std::unique_ptr<rpg::Save>();
+		LcfReader::SetError("Couldn't parse save file.");
+		return {};
 	}
 	std::string header;
 	reader.ReadString(header, reader.ReadInt());
 	if (header.length() != 11) {
-		LcfReader::SetError("This is not a valid RPG2000 save.\n");
-		return std::unique_ptr<rpg::Save>();
+		LcfReader::SetError("This is not a valid RPG2000 save.");
+		return {};
 	}
 	if (header != "LcfSaveData") {
-		fprintf(stderr, "Warning: This header is not LcfSaveData and might not be a valid RPG2000 save.\n");
+		Log::Warning("Header %s != LcfSaveData and might not be a valid RPG2000 save.", header.c_str());
 	}
 
 	auto pos = reader.Tell();
@@ -104,8 +104,8 @@ std::unique_ptr<rpg::Save> LSD_Reader::Load(std::istream& filestream, StringView
 		filestream.seekg(pos, std::ios_base::beg);
 		LcfReader reader2(filestream, std::to_string(save->easyrpg_data.codepage));
 		if (!reader2.IsOk()) {
-			LcfReader::SetError("Couldn't parse save file.\n");
-			return std::unique_ptr<rpg::Save>();
+			LcfReader::SetError("Couldn't parse save file.");
+			return {};
 		}
 		save.reset(new rpg::Save());
 		Struct<rpg::Save>::ReadLcf(*save, reader2);
@@ -139,7 +139,7 @@ bool LSD_Reader::Save(std::ostream& filestream, const rpg::Save& save, EngineVer
 bool LSD_Reader::SaveXml(std::ostream& filestream, const rpg::Save& save, EngineVersion engine) {
 	XmlWriter writer(filestream, engine);
 	if (!writer.IsOk()) {
-		LcfReader::SetError("Couldn't parse save file.\n");
+		LcfReader::SetError("Couldn't parse save file.");
 		return false;
 	}
 
@@ -152,8 +152,8 @@ bool LSD_Reader::SaveXml(std::ostream& filestream, const rpg::Save& save, Engine
 std::unique_ptr<rpg::Save> LSD_Reader::LoadXml(std::istream& filestream) {
 	XmlReader reader(filestream);
 	if (!reader.IsOk()) {
-		LcfReader::SetError("Couldn't parse save file.\n");
-		return std::unique_ptr<rpg::Save>();
+		LcfReader::SetError("Couldn't parse save file.");
+		return {};
 	}
 
 	rpg::Save* save = new rpg::Save();

--- a/src/reader_flags.cpp
+++ b/src/reader_flags.cpp
@@ -46,7 +46,7 @@ void Flags<S>::ReadLcf(S& obj, LcfReader& stream, uint32_t length) {
 	for (size_t i = 0; i < obj.flags.size(); ++i) {
 		x |= (obj.flags[i] << i);
 	}
-	printf("0x%lx\n", x);
+	fprintf(stderr, "0x%lx\n", x);
 #endif
 }
 
@@ -118,7 +118,7 @@ public:
 	void StartElement(XmlReader& stream, const char* name, const char** /* atts */) {
 		const auto idx = Flags<S>::idx(name);
 		if (idx < 0) {
-			stream.Error("Unrecognized field '%s'", name);
+			Log::Error("XML: Unrecognized field '%s'", name);
 			field = NULL;
 			return;
 		}

--- a/src/reader_lcf.cpp
+++ b/src/reader_lcf.cpp
@@ -13,6 +13,7 @@
 #include <limits>
 
 #include "lcf/reader_lcf.h"
+#include "log.h"
 
 namespace lcf {
 // Statics
@@ -276,7 +277,7 @@ int LcfReader::Peek() {
 }
 
 void LcfReader::Skip(const struct LcfReader::Chunk& chunk_info, const char* where) {
-	fprintf(stderr, "Skipped Chunk %02X (%" PRIu32 " byte) in lcf at %" PRIX32 " (%s)\n",
+	Log::Debug("Skipped Chunk %02X (%" PRIu32 " byte) in lcf at %" PRIX32 " (%s)\n",
 			chunk_info.ID, chunk_info.length, Tell(), where);
 
 	for (uint32_t i = 0; i < chunk_info.length; ++i) {

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -34,6 +34,7 @@
 #include "lcf/inireader.h"
 #include "lcf/ldb/reader.h"
 #include "lcf/reader_util.h"
+#include "log.h"
 
 namespace lcf {
 
@@ -275,7 +276,7 @@ std::string ReaderUtil::Normalize(StringView str) {
 	if (U_FAILURE(err)) {
 		static bool err_reported = false;
 		if (!err_reported) {
-			fprintf(stderr, "Normalizer2::getNFKCInstance failed (%s). \"nrm\" is probably missing in the ICU data file. Unicode normalization will not work!\n", u_errorName(err));
+			Log::Warning("Normalizer2::getNFKCInstance failed (%s). \"nrm\" is probably missing in the ICU data file. Unicode normalization will not work!", u_errorName(err));
 			err_reported = true;
 		}
 		uni.toUTF8String(res);

--- a/src/reader_xml.cpp
+++ b/src/reader_xml.cpp
@@ -12,6 +12,7 @@
 #include "lcf/reader_lcf.h"
 #include "lcf/reader_xml.h"
 #include "lcf/dbstring.h"
+#include "log.h"
 
 // Expat callbacks
 #if LCF_SUPPORT_XML
@@ -59,14 +60,6 @@ bool XmlReader::IsOk() const {
 	return (stream.good() && parser != NULL);
 }
 
-void XmlReader::Error(const char* fmt, ...) {
-	va_list ap;
-	va_start(ap, fmt);
-	vfprintf(stderr, fmt, ap);
-	fputc('\n', stderr);
-	va_end(ap);
-}
-
 void XmlReader::Parse() {
 #if LCF_SUPPORT_XML
 	static const int bufsize = 4096;
@@ -75,7 +68,7 @@ void XmlReader::Parse() {
 		int len = stream.read(reinterpret_cast<char*>(buffer),bufsize).gcount();
 		int result = XML_ParseBuffer(parser, len, len <= 0);
 		if (result == 0)
-			Error("%s", XML_ErrorString(XML_GetErrorCode(parser)));
+			Log::Error("XML: %s", XML_ErrorString(XML_GetErrorCode(parser)));
 	}
 #endif
 }


### PR DESCRIPTION
First commit: The chunk dumping during Skip didnt really work except on Windows. I finally fixed it (useful for Maniacs Patch to find unknown chunks). Also is now always on, a missing chunk is now always a bug because we know about all common ones.

Second commit: **I want your feedback here**. Before I implement this completely (is some work) please tell me if the general approach is fine for you.
I want to allow custom output handlers for lcf diagnostics. E.g. for the Player they could be written to easyrpg_log.txt. Currently they are completely lost which is bad for handling bug reports. As vital information is missing.

To redirect it library users can invoke lcf::LogHandler::SetHandler(_Handlerfunctionhere_)