### PR TITLE
Add custom game settings in the database

### DIFF
--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -11,8 +11,17 @@ SaveSystem,maniac_frameskip,,Int32,0x88,0,0,0,"FatalMix Frameskip (0=None, 1=1/5
 SaveSystem,maniac_picture_limit,,Int32,0x89,0,0,0,FatalMix Picture Limit
 SaveSystem,maniac_options,,Vector<UInt8>,0x8A,,0,0,"Various FatalMix options (XX XA XB XC). A: MsgSkip OFF/RShift (0/4) B: TestPlay Keep/ON/OFF (0/2/4), C: Pause focus lost Wait/Run (0/1)"
 SaveSystem,maniac_joypad_bindings,,Vector<UInt8>,0x8B,,0,0,"JoyLeft, JoyRight, JoyUp, JoyDown, Joy1, ... Joy12"
+BattleCommands,easyrpg_default_atb_mode,f,Enum<SaveSystem_AtbMode>,0xC8,0,0,1,Default ATB mode of RPG 2003 battle system
+BattleCommands,easyrpg_enable_battle_row_command,f,Boolean,0xC9,True,0,1,If the row command should be enabled in RPG Maker 2003 battles
+BattleCommands,easyrpg_sequential_order,f,Boolean,0xCA,False,0,1,If alternative and gauge style battles should behave like traditional style battles
 Skill,easyrpg_battle2k3_message,f,DBString,0xC9,DBString(kDefaultMessage),0,1,RPG Maker 2003 battle skill start notification
+Skill,easyrpg_ignore_reflect,f,Boolean,0xCA,False,0,1,If the skill bypasses reflect states. Useful for physical skills and skills which are meant to remove positive states from enemies
+Skill,easyrpg_state_hit,f,Int32,0xCB,-1,0,0,Separate accuracy value for state inflictions
+Skill,easyrpg_attribute_hit,f,Int32,0xCC,-1,0,0,Separate accuracy value for attribute shifts
+Skill,easyrpg_ignore_restrict_skill,f,Boolean,0xCD,False,0,0,If the skill should bypass skill restrictions by states
+Skill,easyrpg_ignore_restrict_magic,f,Boolean,0xCE,False,0,0,If the skill should bypass magic restrictions by states
 Item,easyrpg_using_message,f,DBString,0xC9,DBString(kDefaultMessage),0,0,Item usage message in battle
+Item,easyrpg_max_count,f,Int32,0xCA,-1,0,0,How many the player can carry of this item
 Terms,easyrpg_item_number_separator,f,DBString,0xC8,DBString(kDefaultTerm),0,0,Item number separator
 Terms,easyrpg_skill_cost_separator,f,DBString,0xC9,DBString(kDefaultTerm),0,0,Skill cost separator
 Terms,easyrpg_equipment_arrow,f,DBString,0xCA,DBString(kDefaultTerm),0,0,Equipment window arrow
@@ -33,3 +42,19 @@ Terms,easyrpg_battle2k3_escape,f,DBString,0xD8,DBString(kDefaultTerm),0,1,RPG Ma
 Terms,easyrpg_battle2k3_special_combat_back,f,DBString,0xD9,,0,1,Message for back and pincer attack
 Terms,easyrpg_battle2k3_skill,f,DBString,0xDA,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle general skill start notification
 Terms,easyrpg_battle2k3_item,f,DBString,0xDB,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle general item start notification
+System,easyrpg_alternative_exp,f,Int32,0xC8,0,0,0,Which EXP formula to use: 0=Default 1=2k 2=2k3
+System,easyrpg_enable_auto_battle,f,Boolean,0xC9,True,0,0,If auto battling should be allowed
+System,easyrpg_max_actor_hp,f,Int32,0xCA,-1,0,0,Absolute maximum HP value actors can have
+System,easyrpg_max_enemy_hp,f,Int32,0xCB,-1,0,0,Absolute maximum HP value enemies can have
+System,easyrpg_max_damage,f,Int32,0xCC,-1,0,0,How much damage can an attack inflict at most
+System,easyrpg_max_exp,f,Int32,0xCD,-1,0,0,Absolute maximum EXP value actors can have
+System,easyrpg_max_level,f,Int32,0xCE,-1,0,0,Absolute maximum level actors can reach
+System,easyrpg_enable_stat_absorbing,f,Boolean,0xCF,False,0,0,If attack/defense/spirit/agility can be absorbed
+System,easyrpg_max_savefiles,f,Int32,0xD0,15,0,0,How many savegame slots should be shown in the savegame scene
+System,easyrpg_max_item_count,f,Int32,0xD1,-1,0,0,How many items of a kind the player can carry. Can be overridden per item with the easyrpg_max_count setting of an item
+System,easyrpg_variable_min_value,f,Int32,0xD2,0,0,0,Minimum value a variable can have
+System,easyrpg_variable_max_value,f,Int32,0xD3,0,0,0,Maximum value a variable can have
+System,easyrpg_max_actor_sp,f,Int32,0xD4,-1,0,0,Absolute maximum SP value actors can have
+System,easyrpg_max_enemy_sp,f,Int32,0xD5,-1,0,0,Absolute maximum SP value enemies can have
+System,easyrpg_max_stat_base_value,f,Int32,0xD6,-1,0,0,Absolute maximum value a base stat can have
+System,easyrpg_max_stat_battle_value,f,Int32,0xD7,-1,0,0,Absolute maximum value a battle stat can have

--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -43,7 +43,7 @@ Terms,easyrpg_battle2k3_special_combat_back,f,DBString,0xD9,,0,1,Message for bac
 Terms,easyrpg_battle2k3_skill,f,DBString,0xDA,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle general skill start notification
 Terms,easyrpg_battle2k3_item,f,DBString,0xDB,DBString(kDefaultTerm),0,1,RPG Maker 2003 battle general item start notification
 System,easyrpg_alternative_exp,f,Int32,0xC8,0,0,0,Which EXP formula to use: 0=Default 1=2k 2=2k3
-System,easyrpg_enable_auto_battle,f,Boolean,0xC9,True,0,0,If auto battling should be allowed
+System,easyrpg_battle_options,f,Vector<Int16>,0xC9,"[0,1,2]",0,0,Available battle options where 0=Battle 1=AutoBattle 2=Escape
 System,easyrpg_max_actor_hp,f,Int32,0xCA,-1,0,0,Absolute maximum HP value actors can have
 System,easyrpg_max_enemy_hp,f,Int32,0xCB,-1,0,0,Absolute maximum HP value enemies can have
 System,easyrpg_max_damage,f,Int32,0xCC,-1,0,0,How much damage can an attack inflict at most

--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -20,6 +20,7 @@ Skill,easyrpg_state_hit,f,Int32,0xCB,-1,0,0,Separate accuracy value for state in
 Skill,easyrpg_attribute_hit,f,Int32,0xCC,-1,0,0,Separate accuracy value for attribute shifts
 Skill,easyrpg_ignore_restrict_skill,f,Boolean,0xCD,False,0,0,If the skill should bypass skill restrictions by states
 Skill,easyrpg_ignore_restrict_magic,f,Boolean,0xCE,False,0,0,If the skill should bypass magic restrictions by states
+Skill,easyrpg_enable_stat_absorbing,f,Boolean,0xCF,False,0,0,If the skill can absorb attack/defense/spirit/agility
 Item,easyrpg_using_message,f,DBString,0xC9,DBString(kDefaultMessage),0,0,Item usage message in battle
 Item,easyrpg_max_count,f,Int32,0xCA,-1,0,0,How many the player can carry of this item
 Terms,easyrpg_item_number_separator,f,DBString,0xC8,DBString(kDefaultTerm),0,0,Item number separator
@@ -49,12 +50,11 @@ System,easyrpg_max_enemy_hp,f,Int32,0xCB,-1,0,0,Absolute maximum HP value enemie
 System,easyrpg_max_damage,f,Int32,0xCC,-1,0,0,How much damage can an attack inflict at most
 System,easyrpg_max_exp,f,Int32,0xCD,-1,0,0,Absolute maximum EXP value actors can have
 System,easyrpg_max_level,f,Int32,0xCE,-1,0,0,Absolute maximum level actors can reach
-System,easyrpg_enable_stat_absorbing,f,Boolean,0xCF,False,0,0,If attack/defense/spirit/agility can be absorbed
-System,easyrpg_max_savefiles,f,Int32,0xD0,15,0,0,How many savegame slots should be shown in the savegame scene
-System,easyrpg_max_item_count,f,Int32,0xD1,-1,0,0,How many items of a kind the player can carry. Can be overridden per item with the easyrpg_max_count setting of an item
-System,easyrpg_variable_min_value,f,Int32,0xD2,0,0,0,Minimum value a variable can have
-System,easyrpg_variable_max_value,f,Int32,0xD3,0,0,0,Maximum value a variable can have
-System,easyrpg_max_actor_sp,f,Int32,0xD4,-1,0,0,Absolute maximum SP value actors can have
-System,easyrpg_max_enemy_sp,f,Int32,0xD5,-1,0,0,Absolute maximum SP value enemies can have
-System,easyrpg_max_stat_base_value,f,Int32,0xD6,-1,0,0,Absolute maximum value a base stat can have
-System,easyrpg_max_stat_battle_value,f,Int32,0xD7,-1,0,0,Absolute maximum value a battle stat can have
+System,easyrpg_max_savefiles,f,Int32,0xCF,15,0,0,How many savegame slots should be shown in the savegame scene
+System,easyrpg_max_item_count,f,Int32,0xD0,-1,0,0,How many items of a kind the player can carry. Can be overridden per item with the easyrpg_max_count setting of an item
+System,easyrpg_variable_min_value,f,Int32,0xD1,0,0,0,Minimum value a variable can have
+System,easyrpg_variable_max_value,f,Int32,0xD2,0,0,0,Maximum value a variable can have
+System,easyrpg_max_actor_sp,f,Int32,0xD3,-1,0,0,Absolute maximum SP value actors can have
+System,easyrpg_max_enemy_sp,f,Int32,0xD4,-1,0,0,Absolute maximum SP value enemies can have
+System,easyrpg_max_stat_base_value,f,Int32,0xD5,-1,0,0,Absolute maximum value a base stat can have
+System,easyrpg_max_stat_battle_value,f,Int32,0xD6,-1,0,0,Absolute maximum value a battle stat can have

--- a/src/generated/lcf/ldb/chunks.h
+++ b/src/generated/lcf/ldb/chunks.h
@@ -233,7 +233,13 @@ namespace LDB_Reader {
 			/** Integer */
 			death_teleport_y = 0x1C,
 			/** Integer */
-			death_teleport_face = 0x1D
+			death_teleport_face = 0x1D,
+			/** Default ATB mode of RPG 2003 battle system */
+			easyrpg_default_atb_mode = 0xC8,
+			/** If the row command should be enabled in RPG Maker 2003 battles */
+			easyrpg_enable_battle_row_command = 0xC9,
+			/** If alternative and gauge style battles should behave like traditional style battles */
+			easyrpg_sequential_order = 0xCA
 		};
 	};
 	struct ChunkBattlerAnimation {
@@ -443,7 +449,17 @@ namespace LDB_Reader {
 			/** ? - RPG2003 */
 			battler_animation_data = 0x32,
 			/** RPG Maker 2003 battle skill start notification */
-			easyrpg_battle2k3_message = 0xC9
+			easyrpg_battle2k3_message = 0xC9,
+			/** If the skill bypasses reflect states. Useful for physical skills and skills which are meant to remove positive states from enemies */
+			easyrpg_ignore_reflect = 0xCA,
+			/** Separate accuracy value for state inflictions */
+			easyrpg_state_hit = 0xCB,
+			/** Separate accuracy value for attribute shifts */
+			easyrpg_attribute_hit = 0xCC,
+			/** If the skill should bypass skill restrictions by states */
+			easyrpg_ignore_restrict_skill = 0xCD,
+			/** If the skill should bypass magic restrictions by states */
+			easyrpg_ignore_restrict_magic = 0xCE
 		};
 	};
 	struct ChunkItem {
@@ -561,7 +577,9 @@ namespace LDB_Reader {
 			/** Integer */
 			ranged_target = 0x4C,
 			/** Item usage message in battle */
-			easyrpg_using_message = 0xC9
+			easyrpg_using_message = 0xC9,
+			/** How many the player can carry of this item */
+			easyrpg_max_count = 0xCA
 		};
 	};
 	struct ChunkEnemyAction {
@@ -1337,7 +1355,39 @@ namespace LDB_Reader {
 			/** Flag - RPG2003 */
 			invert_animations = 0x65,
 			/** When false the title is skipped and the game starts directly. In TestPlay mode skips directly to the Load scene. Added in RPG Maker 2003 v1.11 */
-			show_title = 0x6F
+			show_title = 0x6F,
+			/** Which EXP formula to use: 0=Default 1=2k 2=2k3 */
+			easyrpg_alternative_exp = 0xC8,
+			/** If auto battling should be allowed */
+			easyrpg_enable_auto_battle = 0xC9,
+			/** Absolute maximum HP value actors can have */
+			easyrpg_max_actor_hp = 0xCA,
+			/** Absolute maximum HP value enemies can have */
+			easyrpg_max_enemy_hp = 0xCB,
+			/** How much damage can an attack inflict at most */
+			easyrpg_max_damage = 0xCC,
+			/** Absolute maximum EXP value actors can have */
+			easyrpg_max_exp = 0xCD,
+			/** Absolute maximum level actors can reach */
+			easyrpg_max_level = 0xCE,
+			/** If attack/defense/spirit/agility can be absorbed */
+			easyrpg_enable_stat_absorbing = 0xCF,
+			/** How many savegame slots should be shown in the savegame scene */
+			easyrpg_max_savefiles = 0xD0,
+			/** How many items of a kind the player can carry. Can be overridden per item with the easyrpg_max_count setting of an item */
+			easyrpg_max_item_count = 0xD1,
+			/** Minimum value a variable can have */
+			easyrpg_variable_min_value = 0xD2,
+			/** Maximum value a variable can have */
+			easyrpg_variable_max_value = 0xD3,
+			/** Absolute maximum SP value actors can have */
+			easyrpg_max_actor_sp = 0xD4,
+			/** Absolute maximum SP value enemies can have */
+			easyrpg_max_enemy_sp = 0xD5,
+			/** Absolute maximum value a base stat can have */
+			easyrpg_max_stat_base_value = 0xD6,
+			/** Absolute maximum value a battle stat can have */
+			easyrpg_max_stat_battle_value = 0xD7
 		};
 	};
 	struct ChunkSwitch {

--- a/src/generated/lcf/ldb/chunks.h
+++ b/src/generated/lcf/ldb/chunks.h
@@ -1358,8 +1358,8 @@ namespace LDB_Reader {
 			show_title = 0x6F,
 			/** Which EXP formula to use: 0=Default 1=2k 2=2k3 */
 			easyrpg_alternative_exp = 0xC8,
-			/** If auto battling should be allowed */
-			easyrpg_enable_auto_battle = 0xC9,
+			/** Available battle options where 0=Battle 1=AutoBattle 2=Escape */
+			easyrpg_battle_options = 0xC9,
 			/** Absolute maximum HP value actors can have */
 			easyrpg_max_actor_hp = 0xCA,
 			/** Absolute maximum HP value enemies can have */

--- a/src/generated/lcf/ldb/chunks.h
+++ b/src/generated/lcf/ldb/chunks.h
@@ -459,7 +459,9 @@ namespace LDB_Reader {
 			/** If the skill should bypass skill restrictions by states */
 			easyrpg_ignore_restrict_skill = 0xCD,
 			/** If the skill should bypass magic restrictions by states */
-			easyrpg_ignore_restrict_magic = 0xCE
+			easyrpg_ignore_restrict_magic = 0xCE,
+			/** If the skill can absorb attack/defense/spirit/agility */
+			easyrpg_enable_stat_absorbing = 0xCF
 		};
 	};
 	struct ChunkItem {
@@ -1370,24 +1372,22 @@ namespace LDB_Reader {
 			easyrpg_max_exp = 0xCD,
 			/** Absolute maximum level actors can reach */
 			easyrpg_max_level = 0xCE,
-			/** If attack/defense/spirit/agility can be absorbed */
-			easyrpg_enable_stat_absorbing = 0xCF,
 			/** How many savegame slots should be shown in the savegame scene */
-			easyrpg_max_savefiles = 0xD0,
+			easyrpg_max_savefiles = 0xCF,
 			/** How many items of a kind the player can carry. Can be overridden per item with the easyrpg_max_count setting of an item */
-			easyrpg_max_item_count = 0xD1,
+			easyrpg_max_item_count = 0xD0,
 			/** Minimum value a variable can have */
-			easyrpg_variable_min_value = 0xD2,
+			easyrpg_variable_min_value = 0xD1,
 			/** Maximum value a variable can have */
-			easyrpg_variable_max_value = 0xD3,
+			easyrpg_variable_max_value = 0xD2,
 			/** Absolute maximum SP value actors can have */
-			easyrpg_max_actor_sp = 0xD4,
+			easyrpg_max_actor_sp = 0xD3,
 			/** Absolute maximum SP value enemies can have */
-			easyrpg_max_enemy_sp = 0xD5,
+			easyrpg_max_enemy_sp = 0xD4,
 			/** Absolute maximum value a base stat can have */
-			easyrpg_max_stat_base_value = 0xD6,
+			easyrpg_max_stat_base_value = 0xD5,
 			/** Absolute maximum value a battle stat can have */
-			easyrpg_max_stat_battle_value = 0xD7
+			easyrpg_max_stat_battle_value = 0xD6
 		};
 	};
 	struct ChunkSwitch {

--- a/src/generated/lcf/rpg/battlecommands.h
+++ b/src/generated/lcf/rpg/battlecommands.h
@@ -100,6 +100,9 @@ namespace rpg {
 		int32_t death_teleport_x = 0;
 		int32_t death_teleport_y = 0;
 		int32_t death_teleport_face = 0;
+		int32_t easyrpg_default_atb_mode = 0;
+		bool easyrpg_enable_battle_row_command = true;
+		bool easyrpg_sequential_order = false;
 	};
 	inline std::ostream& operator<<(std::ostream& os, BattleCommands::Placement code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -141,7 +144,10 @@ namespace rpg {
 		&& l.death_teleport_id == r.death_teleport_id
 		&& l.death_teleport_x == r.death_teleport_x
 		&& l.death_teleport_y == r.death_teleport_y
-		&& l.death_teleport_face == r.death_teleport_face;
+		&& l.death_teleport_face == r.death_teleport_face
+		&& l.easyrpg_default_atb_mode == r.easyrpg_default_atb_mode
+		&& l.easyrpg_enable_battle_row_command == r.easyrpg_enable_battle_row_command
+		&& l.easyrpg_sequential_order == r.easyrpg_sequential_order;
 	}
 
 	inline bool operator!=(const BattleCommands& l, const BattleCommands& r) {

--- a/src/generated/lcf/rpg/item.h
+++ b/src/generated/lcf/rpg/item.h
@@ -134,6 +134,7 @@ namespace rpg {
 		int32_t ranged_trajectory = 0;
 		int32_t ranged_target = 0;
 		DBString easyrpg_using_message = DBString(kDefaultMessage);
+		int32_t easyrpg_max_count = -1;
 	};
 	inline std::ostream& operator<<(std::ostream& os, Item::Type code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -201,7 +202,8 @@ namespace rpg {
 		&& l.class_set == r.class_set
 		&& l.ranged_trajectory == r.ranged_trajectory
 		&& l.ranged_target == r.ranged_target
-		&& l.easyrpg_using_message == r.easyrpg_using_message;
+		&& l.easyrpg_using_message == r.easyrpg_using_message
+		&& l.easyrpg_max_count == r.easyrpg_max_count;
 	}
 
 	inline bool operator!=(const Item& l, const Item& r) {

--- a/src/generated/lcf/rpg/skill.h
+++ b/src/generated/lcf/rpg/skill.h
@@ -107,6 +107,11 @@ namespace rpg {
 		int32_t battler_animation = -1;
 		std::vector<BattlerAnimationItemSkill> battler_animation_data;
 		DBString easyrpg_battle2k3_message = DBString(kDefaultMessage);
+		bool easyrpg_ignore_reflect = false;
+		int32_t easyrpg_state_hit = -1;
+		int32_t easyrpg_attribute_hit = -1;
+		bool easyrpg_ignore_restrict_skill = false;
+		bool easyrpg_ignore_restrict_magic = false;
 	};
 	inline std::ostream& operator<<(std::ostream& os, Skill::Type code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -156,7 +161,12 @@ namespace rpg {
 		&& l.affect_attr_defence == r.affect_attr_defence
 		&& l.battler_animation == r.battler_animation
 		&& l.battler_animation_data == r.battler_animation_data
-		&& l.easyrpg_battle2k3_message == r.easyrpg_battle2k3_message;
+		&& l.easyrpg_battle2k3_message == r.easyrpg_battle2k3_message
+		&& l.easyrpg_ignore_reflect == r.easyrpg_ignore_reflect
+		&& l.easyrpg_state_hit == r.easyrpg_state_hit
+		&& l.easyrpg_attribute_hit == r.easyrpg_attribute_hit
+		&& l.easyrpg_ignore_restrict_skill == r.easyrpg_ignore_restrict_skill
+		&& l.easyrpg_ignore_restrict_magic == r.easyrpg_ignore_restrict_magic;
 	}
 
 	inline bool operator!=(const Skill& l, const Skill& r) {

--- a/src/generated/lcf/rpg/skill.h
+++ b/src/generated/lcf/rpg/skill.h
@@ -112,6 +112,7 @@ namespace rpg {
 		int32_t easyrpg_attribute_hit = -1;
 		bool easyrpg_ignore_restrict_skill = false;
 		bool easyrpg_ignore_restrict_magic = false;
+		bool easyrpg_enable_stat_absorbing = false;
 	};
 	inline std::ostream& operator<<(std::ostream& os, Skill::Type code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -166,7 +167,8 @@ namespace rpg {
 		&& l.easyrpg_state_hit == r.easyrpg_state_hit
 		&& l.easyrpg_attribute_hit == r.easyrpg_attribute_hit
 		&& l.easyrpg_ignore_restrict_skill == r.easyrpg_ignore_restrict_skill
-		&& l.easyrpg_ignore_restrict_magic == r.easyrpg_ignore_restrict_magic;
+		&& l.easyrpg_ignore_restrict_magic == r.easyrpg_ignore_restrict_magic
+		&& l.easyrpg_enable_stat_absorbing == r.easyrpg_enable_stat_absorbing;
 	}
 
 	inline bool operator!=(const Skill& l, const Skill& r) {

--- a/src/generated/lcf/rpg/system.h
+++ b/src/generated/lcf/rpg/system.h
@@ -231,6 +231,22 @@ namespace rpg {
 		DBString frame_name;
 		bool invert_animations = false;
 		bool show_title = true;
+		int32_t easyrpg_alternative_exp = 0;
+		bool easyrpg_enable_auto_battle = true;
+		int32_t easyrpg_max_actor_hp = -1;
+		int32_t easyrpg_max_enemy_hp = -1;
+		int32_t easyrpg_max_damage = -1;
+		int32_t easyrpg_max_exp = -1;
+		int32_t easyrpg_max_level = -1;
+		bool easyrpg_enable_stat_absorbing = false;
+		int32_t easyrpg_max_savefiles = 15;
+		int32_t easyrpg_max_item_count = -1;
+		int32_t easyrpg_variable_min_value = 0;
+		int32_t easyrpg_variable_max_value = 0;
+		int32_t easyrpg_max_actor_sp = -1;
+		int32_t easyrpg_max_enemy_sp = -1;
+		int32_t easyrpg_max_stat_base_value = -1;
+		int32_t easyrpg_max_stat_battle_value = -1;
 	};
 	inline std::ostream& operator<<(std::ostream& os, System::FadeOut code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -316,7 +332,23 @@ namespace rpg {
 		&& l.show_frame == r.show_frame
 		&& l.frame_name == r.frame_name
 		&& l.invert_animations == r.invert_animations
-		&& l.show_title == r.show_title;
+		&& l.show_title == r.show_title
+		&& l.easyrpg_alternative_exp == r.easyrpg_alternative_exp
+		&& l.easyrpg_enable_auto_battle == r.easyrpg_enable_auto_battle
+		&& l.easyrpg_max_actor_hp == r.easyrpg_max_actor_hp
+		&& l.easyrpg_max_enemy_hp == r.easyrpg_max_enemy_hp
+		&& l.easyrpg_max_damage == r.easyrpg_max_damage
+		&& l.easyrpg_max_exp == r.easyrpg_max_exp
+		&& l.easyrpg_max_level == r.easyrpg_max_level
+		&& l.easyrpg_enable_stat_absorbing == r.easyrpg_enable_stat_absorbing
+		&& l.easyrpg_max_savefiles == r.easyrpg_max_savefiles
+		&& l.easyrpg_max_item_count == r.easyrpg_max_item_count
+		&& l.easyrpg_variable_min_value == r.easyrpg_variable_min_value
+		&& l.easyrpg_variable_max_value == r.easyrpg_variable_max_value
+		&& l.easyrpg_max_actor_sp == r.easyrpg_max_actor_sp
+		&& l.easyrpg_max_enemy_sp == r.easyrpg_max_enemy_sp
+		&& l.easyrpg_max_stat_base_value == r.easyrpg_max_stat_base_value
+		&& l.easyrpg_max_stat_battle_value == r.easyrpg_max_stat_battle_value;
 	}
 
 	inline bool operator!=(const System& l, const System& r) {

--- a/src/generated/lcf/rpg/system.h
+++ b/src/generated/lcf/rpg/system.h
@@ -238,7 +238,6 @@ namespace rpg {
 		int32_t easyrpg_max_damage = -1;
 		int32_t easyrpg_max_exp = -1;
 		int32_t easyrpg_max_level = -1;
-		bool easyrpg_enable_stat_absorbing = false;
 		int32_t easyrpg_max_savefiles = 15;
 		int32_t easyrpg_max_item_count = -1;
 		int32_t easyrpg_variable_min_value = 0;
@@ -340,7 +339,6 @@ namespace rpg {
 		&& l.easyrpg_max_damage == r.easyrpg_max_damage
 		&& l.easyrpg_max_exp == r.easyrpg_max_exp
 		&& l.easyrpg_max_level == r.easyrpg_max_level
-		&& l.easyrpg_enable_stat_absorbing == r.easyrpg_enable_stat_absorbing
 		&& l.easyrpg_max_savefiles == r.easyrpg_max_savefiles
 		&& l.easyrpg_max_item_count == r.easyrpg_max_item_count
 		&& l.easyrpg_variable_min_value == r.easyrpg_variable_min_value

--- a/src/generated/lcf/rpg/system.h
+++ b/src/generated/lcf/rpg/system.h
@@ -232,7 +232,7 @@ namespace rpg {
 		bool invert_animations = false;
 		bool show_title = true;
 		int32_t easyrpg_alternative_exp = 0;
-		bool easyrpg_enable_auto_battle = true;
+		std::vector<int16_t> easyrpg_battle_options = {0, 1, 2};
 		int32_t easyrpg_max_actor_hp = -1;
 		int32_t easyrpg_max_enemy_hp = -1;
 		int32_t easyrpg_max_damage = -1;
@@ -334,7 +334,7 @@ namespace rpg {
 		&& l.invert_animations == r.invert_animations
 		&& l.show_title == r.show_title
 		&& l.easyrpg_alternative_exp == r.easyrpg_alternative_exp
-		&& l.easyrpg_enable_auto_battle == r.easyrpg_enable_auto_battle
+		&& l.easyrpg_battle_options == r.easyrpg_battle_options
 		&& l.easyrpg_max_actor_hp == r.easyrpg_max_actor_hp
 		&& l.easyrpg_max_enemy_hp == r.easyrpg_max_enemy_hp
 		&& l.easyrpg_max_damage == r.easyrpg_max_damage

--- a/src/generated/ldb_battlecommands.cpp
+++ b/src/generated/ldb_battlecommands.cpp
@@ -125,6 +125,27 @@ static TypedField<rpg::BattleCommands, int32_t> static_death_teleport_face(
 	0,
 	0
 );
+static TypedField<rpg::BattleCommands, int32_t> static_easyrpg_default_atb_mode(
+	&rpg::BattleCommands::easyrpg_default_atb_mode,
+	LDB_Reader::ChunkBattleCommands::easyrpg_default_atb_mode,
+	"easyrpg_default_atb_mode",
+	0,
+	1
+);
+static TypedField<rpg::BattleCommands, bool> static_easyrpg_enable_battle_row_command(
+	&rpg::BattleCommands::easyrpg_enable_battle_row_command,
+	LDB_Reader::ChunkBattleCommands::easyrpg_enable_battle_row_command,
+	"easyrpg_enable_battle_row_command",
+	0,
+	1
+);
+static TypedField<rpg::BattleCommands, bool> static_easyrpg_sequential_order(
+	&rpg::BattleCommands::easyrpg_sequential_order,
+	LDB_Reader::ChunkBattleCommands::easyrpg_sequential_order,
+	"easyrpg_sequential_order",
+	0,
+	1
+);
 
 
 template <>
@@ -144,6 +165,9 @@ Field<rpg::BattleCommands> const* Struct<rpg::BattleCommands>::fields[] = {
 	&static_death_teleport_x,
 	&static_death_teleport_y,
 	&static_death_teleport_face,
+	&static_easyrpg_default_atb_mode,
+	&static_easyrpg_enable_battle_row_command,
+	&static_easyrpg_sequential_order,
 	NULL
 };
 

--- a/src/generated/ldb_item.cpp
+++ b/src/generated/ldb_item.cpp
@@ -415,6 +415,13 @@ static TypedField<rpg::Item, DBString> static_easyrpg_using_message(
 	0,
 	0
 );
+static TypedField<rpg::Item, int32_t> static_easyrpg_max_count(
+	&rpg::Item::easyrpg_max_count,
+	LDB_Reader::ChunkItem::easyrpg_max_count,
+	"easyrpg_max_count",
+	0,
+	0
+);
 
 
 template <>
@@ -476,6 +483,7 @@ Field<rpg::Item> const* Struct<rpg::Item>::fields[] = {
 	&static_ranged_trajectory,
 	&static_ranged_target,
 	&static_easyrpg_using_message,
+	&static_easyrpg_max_count,
 	NULL
 };
 

--- a/src/generated/ldb_skill.cpp
+++ b/src/generated/ldb_skill.cpp
@@ -277,6 +277,41 @@ static TypedField<rpg::Skill, DBString> static_easyrpg_battle2k3_message(
 	0,
 	1
 );
+static TypedField<rpg::Skill, bool> static_easyrpg_ignore_reflect(
+	&rpg::Skill::easyrpg_ignore_reflect,
+	LDB_Reader::ChunkSkill::easyrpg_ignore_reflect,
+	"easyrpg_ignore_reflect",
+	0,
+	1
+);
+static TypedField<rpg::Skill, int32_t> static_easyrpg_state_hit(
+	&rpg::Skill::easyrpg_state_hit,
+	LDB_Reader::ChunkSkill::easyrpg_state_hit,
+	"easyrpg_state_hit",
+	0,
+	0
+);
+static TypedField<rpg::Skill, int32_t> static_easyrpg_attribute_hit(
+	&rpg::Skill::easyrpg_attribute_hit,
+	LDB_Reader::ChunkSkill::easyrpg_attribute_hit,
+	"easyrpg_attribute_hit",
+	0,
+	0
+);
+static TypedField<rpg::Skill, bool> static_easyrpg_ignore_restrict_skill(
+	&rpg::Skill::easyrpg_ignore_restrict_skill,
+	LDB_Reader::ChunkSkill::easyrpg_ignore_restrict_skill,
+	"easyrpg_ignore_restrict_skill",
+	0,
+	0
+);
+static TypedField<rpg::Skill, bool> static_easyrpg_ignore_restrict_magic(
+	&rpg::Skill::easyrpg_ignore_restrict_magic,
+	LDB_Reader::ChunkSkill::easyrpg_ignore_restrict_magic,
+	"easyrpg_ignore_restrict_magic",
+	0,
+	0
+);
 
 
 template <>
@@ -318,6 +353,11 @@ Field<rpg::Skill> const* Struct<rpg::Skill>::fields[] = {
 	&static_battler_animation,
 	&static_battler_animation_data,
 	&static_easyrpg_battle2k3_message,
+	&static_easyrpg_ignore_reflect,
+	&static_easyrpg_state_hit,
+	&static_easyrpg_attribute_hit,
+	&static_easyrpg_ignore_restrict_skill,
+	&static_easyrpg_ignore_restrict_magic,
 	NULL
 };
 

--- a/src/generated/ldb_skill.cpp
+++ b/src/generated/ldb_skill.cpp
@@ -312,6 +312,13 @@ static TypedField<rpg::Skill, bool> static_easyrpg_ignore_restrict_magic(
 	0,
 	0
 );
+static TypedField<rpg::Skill, bool> static_easyrpg_enable_stat_absorbing(
+	&rpg::Skill::easyrpg_enable_stat_absorbing,
+	LDB_Reader::ChunkSkill::easyrpg_enable_stat_absorbing,
+	"easyrpg_enable_stat_absorbing",
+	0,
+	0
+);
 
 
 template <>
@@ -358,6 +365,7 @@ Field<rpg::Skill> const* Struct<rpg::Skill>::fields[] = {
 	&static_easyrpg_attribute_hit,
 	&static_easyrpg_ignore_restrict_skill,
 	&static_easyrpg_ignore_restrict_magic,
+	&static_easyrpg_enable_stat_absorbing,
 	NULL
 };
 

--- a/src/generated/ldb_system.cpp
+++ b/src/generated/ldb_system.cpp
@@ -417,6 +417,118 @@ static TypedField<rpg::System, bool> static_show_title(
 	0,
 	1
 );
+static TypedField<rpg::System, int32_t> static_easyrpg_alternative_exp(
+	&rpg::System::easyrpg_alternative_exp,
+	LDB_Reader::ChunkSystem::easyrpg_alternative_exp,
+	"easyrpg_alternative_exp",
+	0,
+	0
+);
+static TypedField<rpg::System, bool> static_easyrpg_enable_auto_battle(
+	&rpg::System::easyrpg_enable_auto_battle,
+	LDB_Reader::ChunkSystem::easyrpg_enable_auto_battle,
+	"easyrpg_enable_auto_battle",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_actor_hp(
+	&rpg::System::easyrpg_max_actor_hp,
+	LDB_Reader::ChunkSystem::easyrpg_max_actor_hp,
+	"easyrpg_max_actor_hp",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_enemy_hp(
+	&rpg::System::easyrpg_max_enemy_hp,
+	LDB_Reader::ChunkSystem::easyrpg_max_enemy_hp,
+	"easyrpg_max_enemy_hp",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_damage(
+	&rpg::System::easyrpg_max_damage,
+	LDB_Reader::ChunkSystem::easyrpg_max_damage,
+	"easyrpg_max_damage",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_exp(
+	&rpg::System::easyrpg_max_exp,
+	LDB_Reader::ChunkSystem::easyrpg_max_exp,
+	"easyrpg_max_exp",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_level(
+	&rpg::System::easyrpg_max_level,
+	LDB_Reader::ChunkSystem::easyrpg_max_level,
+	"easyrpg_max_level",
+	0,
+	0
+);
+static TypedField<rpg::System, bool> static_easyrpg_enable_stat_absorbing(
+	&rpg::System::easyrpg_enable_stat_absorbing,
+	LDB_Reader::ChunkSystem::easyrpg_enable_stat_absorbing,
+	"easyrpg_enable_stat_absorbing",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_savefiles(
+	&rpg::System::easyrpg_max_savefiles,
+	LDB_Reader::ChunkSystem::easyrpg_max_savefiles,
+	"easyrpg_max_savefiles",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_item_count(
+	&rpg::System::easyrpg_max_item_count,
+	LDB_Reader::ChunkSystem::easyrpg_max_item_count,
+	"easyrpg_max_item_count",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_variable_min_value(
+	&rpg::System::easyrpg_variable_min_value,
+	LDB_Reader::ChunkSystem::easyrpg_variable_min_value,
+	"easyrpg_variable_min_value",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_variable_max_value(
+	&rpg::System::easyrpg_variable_max_value,
+	LDB_Reader::ChunkSystem::easyrpg_variable_max_value,
+	"easyrpg_variable_max_value",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_actor_sp(
+	&rpg::System::easyrpg_max_actor_sp,
+	LDB_Reader::ChunkSystem::easyrpg_max_actor_sp,
+	"easyrpg_max_actor_sp",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_enemy_sp(
+	&rpg::System::easyrpg_max_enemy_sp,
+	LDB_Reader::ChunkSystem::easyrpg_max_enemy_sp,
+	"easyrpg_max_enemy_sp",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_stat_base_value(
+	&rpg::System::easyrpg_max_stat_base_value,
+	LDB_Reader::ChunkSystem::easyrpg_max_stat_base_value,
+	"easyrpg_max_stat_base_value",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_max_stat_battle_value(
+	&rpg::System::easyrpg_max_stat_battle_value,
+	LDB_Reader::ChunkSystem::easyrpg_max_stat_battle_value,
+	"easyrpg_max_stat_battle_value",
+	0,
+	0
+);
 
 
 template <>
@@ -478,6 +590,22 @@ Field<rpg::System> const* Struct<rpg::System>::fields[] = {
 	&static_frame_name,
 	&static_invert_animations,
 	&static_show_title,
+	&static_easyrpg_alternative_exp,
+	&static_easyrpg_enable_auto_battle,
+	&static_easyrpg_max_actor_hp,
+	&static_easyrpg_max_enemy_hp,
+	&static_easyrpg_max_damage,
+	&static_easyrpg_max_exp,
+	&static_easyrpg_max_level,
+	&static_easyrpg_enable_stat_absorbing,
+	&static_easyrpg_max_savefiles,
+	&static_easyrpg_max_item_count,
+	&static_easyrpg_variable_min_value,
+	&static_easyrpg_variable_max_value,
+	&static_easyrpg_max_actor_sp,
+	&static_easyrpg_max_enemy_sp,
+	&static_easyrpg_max_stat_base_value,
+	&static_easyrpg_max_stat_battle_value,
 	NULL
 };
 

--- a/src/generated/ldb_system.cpp
+++ b/src/generated/ldb_system.cpp
@@ -466,13 +466,6 @@ static TypedField<rpg::System, int32_t> static_easyrpg_max_level(
 	0,
 	0
 );
-static TypedField<rpg::System, bool> static_easyrpg_enable_stat_absorbing(
-	&rpg::System::easyrpg_enable_stat_absorbing,
-	LDB_Reader::ChunkSystem::easyrpg_enable_stat_absorbing,
-	"easyrpg_enable_stat_absorbing",
-	0,
-	0
-);
 static TypedField<rpg::System, int32_t> static_easyrpg_max_savefiles(
 	&rpg::System::easyrpg_max_savefiles,
 	LDB_Reader::ChunkSystem::easyrpg_max_savefiles,
@@ -597,7 +590,6 @@ Field<rpg::System> const* Struct<rpg::System>::fields[] = {
 	&static_easyrpg_max_damage,
 	&static_easyrpg_max_exp,
 	&static_easyrpg_max_level,
-	&static_easyrpg_enable_stat_absorbing,
 	&static_easyrpg_max_savefiles,
 	&static_easyrpg_max_item_count,
 	&static_easyrpg_variable_min_value,

--- a/src/generated/ldb_system.cpp
+++ b/src/generated/ldb_system.cpp
@@ -424,10 +424,10 @@ static TypedField<rpg::System, int32_t> static_easyrpg_alternative_exp(
 	0,
 	0
 );
-static TypedField<rpg::System, bool> static_easyrpg_enable_auto_battle(
-	&rpg::System::easyrpg_enable_auto_battle,
-	LDB_Reader::ChunkSystem::easyrpg_enable_auto_battle,
-	"easyrpg_enable_auto_battle",
+static TypedField<rpg::System, std::vector<int16_t>> static_easyrpg_battle_options(
+	&rpg::System::easyrpg_battle_options,
+	LDB_Reader::ChunkSystem::easyrpg_battle_options,
+	"easyrpg_battle_options",
 	0,
 	0
 );
@@ -591,7 +591,7 @@ Field<rpg::System> const* Struct<rpg::System>::fields[] = {
 	&static_invert_animations,
 	&static_show_title,
 	&static_easyrpg_alternative_exp,
-	&static_easyrpg_enable_auto_battle,
+	&static_easyrpg_battle_options,
 	&static_easyrpg_max_actor_hp,
 	&static_easyrpg_max_enemy_hp,
 	&static_easyrpg_max_damage,

--- a/src/generated/rpg_battlecommands.cpp
+++ b/src/generated/rpg_battlecommands.cpp
@@ -36,6 +36,9 @@ std::ostream& operator<<(std::ostream& os, const BattleCommands& obj) {
 	os << ", death_teleport_x="<< obj.death_teleport_x;
 	os << ", death_teleport_y="<< obj.death_teleport_y;
 	os << ", death_teleport_face="<< obj.death_teleport_face;
+	os << ", easyrpg_default_atb_mode="<< obj.easyrpg_default_atb_mode;
+	os << ", easyrpg_enable_battle_row_command="<< obj.easyrpg_enable_battle_row_command;
+	os << ", easyrpg_sequential_order="<< obj.easyrpg_sequential_order;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_item.cpp
+++ b/src/generated/rpg_item.cpp
@@ -91,6 +91,7 @@ std::ostream& operator<<(std::ostream& os, const Item& obj) {
 	os << ", ranged_trajectory="<< obj.ranged_trajectory;
 	os << ", ranged_target="<< obj.ranged_target;
 	os << ", easyrpg_using_message="<< obj.easyrpg_using_message;
+	os << ", easyrpg_max_count="<< obj.easyrpg_max_count;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_skill.cpp
+++ b/src/generated/rpg_skill.cpp
@@ -65,6 +65,11 @@ std::ostream& operator<<(std::ostream& os, const Skill& obj) {
 	}
 	os << "]";
 	os << ", easyrpg_battle2k3_message="<< obj.easyrpg_battle2k3_message;
+	os << ", easyrpg_ignore_reflect="<< obj.easyrpg_ignore_reflect;
+	os << ", easyrpg_state_hit="<< obj.easyrpg_state_hit;
+	os << ", easyrpg_attribute_hit="<< obj.easyrpg_attribute_hit;
+	os << ", easyrpg_ignore_restrict_skill="<< obj.easyrpg_ignore_restrict_skill;
+	os << ", easyrpg_ignore_restrict_magic="<< obj.easyrpg_ignore_restrict_magic;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_skill.cpp
+++ b/src/generated/rpg_skill.cpp
@@ -70,6 +70,7 @@ std::ostream& operator<<(std::ostream& os, const Skill& obj) {
 	os << ", easyrpg_attribute_hit="<< obj.easyrpg_attribute_hit;
 	os << ", easyrpg_ignore_restrict_skill="<< obj.easyrpg_ignore_restrict_skill;
 	os << ", easyrpg_ignore_restrict_magic="<< obj.easyrpg_ignore_restrict_magic;
+	os << ", easyrpg_enable_stat_absorbing="<< obj.easyrpg_enable_stat_absorbing;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_system.cpp
+++ b/src/generated/rpg_system.cpp
@@ -84,6 +84,22 @@ std::ostream& operator<<(std::ostream& os, const System& obj) {
 	os << ", frame_name="<< obj.frame_name;
 	os << ", invert_animations="<< obj.invert_animations;
 	os << ", show_title="<< obj.show_title;
+	os << ", easyrpg_alternative_exp="<< obj.easyrpg_alternative_exp;
+	os << ", easyrpg_enable_auto_battle="<< obj.easyrpg_enable_auto_battle;
+	os << ", easyrpg_max_actor_hp="<< obj.easyrpg_max_actor_hp;
+	os << ", easyrpg_max_enemy_hp="<< obj.easyrpg_max_enemy_hp;
+	os << ", easyrpg_max_damage="<< obj.easyrpg_max_damage;
+	os << ", easyrpg_max_exp="<< obj.easyrpg_max_exp;
+	os << ", easyrpg_max_level="<< obj.easyrpg_max_level;
+	os << ", easyrpg_enable_stat_absorbing="<< obj.easyrpg_enable_stat_absorbing;
+	os << ", easyrpg_max_savefiles="<< obj.easyrpg_max_savefiles;
+	os << ", easyrpg_max_item_count="<< obj.easyrpg_max_item_count;
+	os << ", easyrpg_variable_min_value="<< obj.easyrpg_variable_min_value;
+	os << ", easyrpg_variable_max_value="<< obj.easyrpg_variable_max_value;
+	os << ", easyrpg_max_actor_sp="<< obj.easyrpg_max_actor_sp;
+	os << ", easyrpg_max_enemy_sp="<< obj.easyrpg_max_enemy_sp;
+	os << ", easyrpg_max_stat_base_value="<< obj.easyrpg_max_stat_base_value;
+	os << ", easyrpg_max_stat_battle_value="<< obj.easyrpg_max_stat_battle_value;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_system.cpp
+++ b/src/generated/rpg_system.cpp
@@ -85,7 +85,11 @@ std::ostream& operator<<(std::ostream& os, const System& obj) {
 	os << ", invert_animations="<< obj.invert_animations;
 	os << ", show_title="<< obj.show_title;
 	os << ", easyrpg_alternative_exp="<< obj.easyrpg_alternative_exp;
-	os << ", easyrpg_enable_auto_battle="<< obj.easyrpg_enable_auto_battle;
+	os << ", easyrpg_battle_options=";
+	for (size_t i = 0; i < obj.easyrpg_battle_options.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.easyrpg_battle_options[i];
+	}
+	os << "]";
 	os << ", easyrpg_max_actor_hp="<< obj.easyrpg_max_actor_hp;
 	os << ", easyrpg_max_enemy_hp="<< obj.easyrpg_max_enemy_hp;
 	os << ", easyrpg_max_damage="<< obj.easyrpg_max_damage;

--- a/src/generated/rpg_system.cpp
+++ b/src/generated/rpg_system.cpp
@@ -95,7 +95,6 @@ std::ostream& operator<<(std::ostream& os, const System& obj) {
 	os << ", easyrpg_max_damage="<< obj.easyrpg_max_damage;
 	os << ", easyrpg_max_exp="<< obj.easyrpg_max_exp;
 	os << ", easyrpg_max_level="<< obj.easyrpg_max_level;
-	os << ", easyrpg_enable_stat_absorbing="<< obj.easyrpg_enable_stat_absorbing;
 	os << ", easyrpg_max_savefiles="<< obj.easyrpg_max_savefiles;
 	os << ", easyrpg_max_item_count="<< obj.easyrpg_max_item_count;
 	os << ", easyrpg_variable_min_value="<< obj.easyrpg_variable_min_value;


### PR DESCRIPTION
This PR adds the following database settings, here we can discuss which ones are useful for inclusion. If some options are unclear, then ask away!

- BattleCommands option 200: Default ATB mode
- BattleCommands option 201: Enable in-battle row command
- BattleCommands option 202: Sequential order battling
- Skill option 202: Ignore reflect state
- Skill option 203: State infliction hit rate
- Skill option 204: Attribute shift hit rate
- Skill option 205: Ignore physical rate restriction by states
- Skill option 206: Ignore magical rate restriction by states
- Skill option 207: Enable stat absorbing
- Item option 202: Maximum item count in inventory
- System option 200: Alternative EXP curve
- System option 201: Battle options
- System option 202: Maximum actor HP value
- System option 203: Maximum enemy HP value
- System option 204: Maximum damage value
- System option 205: Maximum EXP value
- System option 206: Maximum level
- System option 207: Maximum number of savegame slots
- System option 208: Default maximum item count in inventory
- System option 209: Minimum variable value
- System option 210: Maximum variable value
- System option 211: Maximum actor SP value
- System option 212: Maximum enemy SP value
- System option 213: Maximum base stat value
- System option 214: Maximum battle stat value

The implementation of the features can be found at https://github.com/rueter37/Player/tree/features.