### PR TITLE
Ignore /.github/ to prevent affecting forks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ Makefile
 
 # tests
 test_runner*
+
+# GitHub
+/.github/


### PR DESCRIPTION
This was working fine so far with issue templates.
However, 2FA accounts need additional personal token permissions otherwise push gets rejected when trying to upload workflow files. To prevent discouraging contributions from forks due to the additional maintenance burden, ignoring this folder seems safe.

**Note:** the 2FA issue is only reproducible when the fork adds or modifies new files to `/.github/workflows/` and then trying to push them to the fork.