### PR TITLE
Add more custom game settings in the database

### DIFF
--- a/generator/csv/enums_easyrpg.csv
+++ b/generator/csv/enums_easyrpg.csv
@@ -33,3 +33,5 @@ SavePicture,EasyRpgFlip,none,0
 SavePicture,EasyRpgFlip,x,1
 SavePicture,EasyRpgFlip,y,2
 SavePicture,EasyRpgFlip,both,3
+Skill,HpType,cost,0
+Skill,HpType,percent,1

--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -1,6 +1,5 @@
 Structure,Field,Size Field?,Type,Index,Default Value,PersistIfDefault,Is2k3,Comment
 Save,easyrpg_data,f,SaveEasyRpgData,0xC8,,0,0,Additional save data written by EasyRPG Player
-Enemy,maniac_unarmed_animation,f,Ref<Animation>,0x0F,1,0,0,Animation for normal enemy attacks
 SaveEasyRpgData,version,,Int32,0x01,0,0,0,Savegame version
 SaveEventExecFrame,maniac_event_info,f,Ref<ManiacEventInfo>,0x0E,0,0,0,Event info bitfield
 SaveEventExecFrame,maniac_event_id,f,Int32,0x0F,0,0,0,Event ID
@@ -16,6 +15,34 @@ SaveSystem,maniac_joypad_bindings,,Vector<UInt8>,0x8B,,0,0,"JoyLeft, JoyRight, J
 BattleCommands,easyrpg_default_atb_mode,f,Enum<SaveSystem_AtbMode>,0xC8,0,0,1,Default ATB mode of RPG 2003 battle system
 BattleCommands,easyrpg_enable_battle_row_command,f,Boolean,0xC9,True,0,1,If the row command should be enabled in RPG Maker 2003 battles
 BattleCommands,easyrpg_sequential_order,f,Boolean,0xCA,False,0,1,If alternative and gauge style battles should behave like traditional style battles
+BattleCommands,easyrpg_disable_row_feature,f,Boolean,0xCB,False,0,1,If the row feature should be disabled in RPG Maker 2003 games
+Actor,easyrpg_actorai,f,Int32,0xC9,-1,0,0,Default autobattle AI behavior of the actor
+Actor,easyrpg_prevent_critical,f,Boolean,0xCA,False,0,0,If the actor is protected against critical hits
+Actor,easyrpg_raise_evasion,f,Boolean,0xCB,False,0,0,If the actor has an increased evasion rate
+Actor,easyrpg_immune_to_attribute_downshifts,f,Boolean,0xCC,False,0,0,If the actor is immune to attribute downshifts
+Actor,easyrpg_ignore_evasion,f,Boolean,0xCD,False,0,0,If the actors unarmed physical attacks ignore evasion
+Actor,easyrpg_unarmed_hit,f,Int32,0xCE,-1,0,0,Hit rate of the actor on unarmed attacks
+Actor,easyrpg_unarmed_state_set,t,DBBitArray,0xCF,,0,0,States inflicted by unarmed normal attacks of the actor
+Actor,easyrpg_unarmed_state_set,f,DBBitArray,0xD0,,1,0,States inflicted by unarmed normal attacks of the actor
+Actor,easyrpg_unarmed_state_chance,f,Int32,0xD1,0,0,0,State infliction probability by unarmed normal attacks of the actor
+Actor,easyrpg_unarmed_attribute_set,t,DBBitArray,0xD2,,0,0,Attributes used by unarmed normal attacks of the actor
+Actor,easyrpg_unarmed_attribute_set,f,DBBitArray,0xD3,,1,0,Attributes used by unarmed normal attacks of the actor
+Actor,easyrpg_dual_attack,f,Boolean,0xD4,False,0,0,If the actors unarmed physical attacks hits twice
+Actor,easyrpg_attack_all,f,Boolean,0xD5,False,0,0,If the actors unarmed physical targets the entire enemy party
+Enemy,maniac_unarmed_animation,f,Ref<Animation>,0x0F,1,0,0,Animation for normal enemy attacks (Maniac Patch only)
+Enemy,easyrpg_enemyai,f,Int32,0xC9,-1,0,0,Default AI behavior of the enemy
+Enemy,easyrpg_prevent_critical,f,Boolean,0xCA,False,0,0,If the enemy is protected against critical hits
+Enemy,easyrpg_raise_evasion,f,Boolean,0xCB,False,0,0,If the enemy has an increased evasion rate
+Enemy,easyrpg_immune_to_attribute_downshifts,f,Boolean,0xCC,False,0,0,If the enemy is immune to attribute downshifts
+Enemy,easyrpg_ignore_evasion,f,Boolean,0xCD,False,0,0,If the enemies unarmed physical attacks ignore evasion
+Enemy,easyrpg_hit,f,Int32,0xCE,-1,0,0,Hit rate of the enemy on normal attacks
+Enemy,easyrpg_state_set,t,DBBitArray,0xCF,,0,0,States inflicted by normal attacks of the enemy
+Enemy,easyrpg_state_set,f,DBBitArray,0xD0,,1,0,States inflicted by normal attacks of the enemy
+Enemy,easyrpg_state_chance,f,Int32,0xD1,0,0,0,State infliction probability by normal attacks of the enemy
+Enemy,easyrpg_attribute_set,t,DBBitArray,0xD2,,0,0,Attributes used by normal attacks of the enemy
+Enemy,easyrpg_attribute_set,f,DBBitArray,0xD3,,1,0,Attributes used by normal attacks of the enemy
+Enemy,easyrpg_super_guard,f,Boolean,0xD4,False,0,0,If the enemies defend action quarters instead of halves HP damage
+Enemy,easyrpg_attack_all,f,Boolean,0xD5,False,0,0,If the enemies unarmed physical targets the entire player party
 Skill,easyrpg_battle2k3_message,f,DBString,0xC9,DBString(kDefaultMessage),0,1,RPG Maker 2003 battle skill start notification
 Skill,easyrpg_ignore_reflect,f,Boolean,0xCA,False,0,1,If the skill bypasses reflect states. Useful for physical skills and skills which are meant to remove positive states from enemies
 Skill,easyrpg_state_hit,f,Int32,0xCB,-1,0,0,Separate accuracy value for state inflictions
@@ -23,8 +50,18 @@ Skill,easyrpg_attribute_hit,f,Int32,0xCC,-1,0,0,Separate accuracy value for attr
 Skill,easyrpg_ignore_restrict_skill,f,Boolean,0xCD,False,0,0,If the skill should bypass skill restrictions by states
 Skill,easyrpg_ignore_restrict_magic,f,Boolean,0xCE,False,0,0,If the skill should bypass magic restrictions by states
 Skill,easyrpg_enable_stat_absorbing,f,Boolean,0xCF,False,0,0,If the skill can absorb attack/defense/spirit/agility
+Skill,easyrpg_affected_by_evade_all_physical_attacks,f,Boolean,0xD0,False,0,1,If the skill should be affected by avoid attack states
+Skill,easyrpg_critical_hit_chance,f,Int32,0xD1,0,0,0,Critical hit rate percentage for the skill. If negative then the battler critical hit rate is used
+Skill,easyrpg_affected_by_row_modifiers,f,Boolean,0xD2,False,0,1,If the skill is affected by row modifiers
+Skill,easyrpg_hp_type,f,Enum<Skill_SpType>,0xD3,0,0,1,If the HP usage of the skill is a fixed number or in percent of the maximum HP
+Skill,easyrpg_hp_percent,f,Int32,0xD4,0,0,1,How much percent of the maximum HP does the usage of the skill cost
+Skill,easyrpg_hp_cost,f,Int32,0xD5,0,0,0,How much HP does the usage of the skill cost
 Item,easyrpg_using_message,f,DBString,0xC9,DBString(kDefaultMessage),0,0,Item usage message in battle
 Item,easyrpg_max_count,f,Int32,0xCA,-1,0,0,How many the player can carry of this item
+State,easyrpg_immune_states,t,DBBitArray,0xC8,,0,0,States cleared on infliction by this state
+State,easyrpg_immune_states,f,DBBitArray,0xC9,,1,0,States cleared on infliction by this state
+Terrain,easyrpg_damage_in_percent,f,Boolean,0xC8,False,0,0,If the terrain damage is a percentage
+Terrain,easyrpg_damage_can_kill,f,Boolean,0xC9,False,0,0,If the terrain damage can kill the actors
 Terms,easyrpg_item_number_separator,f,DBString,0xC8,DBString(kDefaultTerm),0,0,Item number separator
 Terms,easyrpg_skill_cost_separator,f,DBString,0xC9,DBString(kDefaultTerm),0,0,Skill cost separator
 Terms,easyrpg_equipment_arrow,f,DBString,0xCA,DBString(kDefaultTerm),0,0,Equipment window arrow
@@ -60,3 +97,8 @@ System,easyrpg_max_actor_sp,f,Int32,0xD3,-1,0,0,Absolute maximum SP value actors
 System,easyrpg_max_enemy_sp,f,Int32,0xD4,-1,0,0,Absolute maximum SP value enemies can have
 System,easyrpg_max_stat_base_value,f,Int32,0xD5,-1,0,0,Absolute maximum value a base stat can have
 System,easyrpg_max_stat_battle_value,f,Int32,0xD6,-1,0,0,Absolute maximum value a battle stat can have
+System,easyrpg_use_rpg2k_battle_system,f,Boolean,0xD7,False,0,1,If the RPG Maker 2000 battle system should be used in RPG Maker 2003 games
+System,easyrpg_battle_use_rpg2ke_strings,f,Boolean,0xD8,False,0,1,If RPG Maker 2000 battles in RPG Maker 2003 games should use the RPG2kE strings
+System,easyrpg_use_rpg2k_battle_commands,f,Boolean,0xD9,False,0,1,If the RPG Maker 2000 battle commands should be used in RPG Maker 2003 games
+System,easyrpg_default_actorai,f,Int32,0xDA,-1,0,0,System default actor AI
+System,easyrpg_default_enemyai,f,Int32,0xDB,-1,0,0,System default enemy AI

--- a/src/generated/lcf/ldb/chunks.h
+++ b/src/generated/lcf/ldb/chunks.h
@@ -93,7 +93,33 @@ namespace LDB_Reader {
 			/** Array - Short */
 			attribute_ranks = 0x4A,
 			/** Array - rpg::BattleCommand - RPG2003 */
-			battle_commands = 0x50
+			battle_commands = 0x50,
+			/** Default autobattle AI behavior of the actor */
+			easyrpg_actorai = 0xC9,
+			/** If the actor is protected against critical hits */
+			easyrpg_prevent_critical = 0xCA,
+			/** If the actor has an increased evasion rate */
+			easyrpg_raise_evasion = 0xCB,
+			/** If the actor is immune to attribute downshifts */
+			easyrpg_immune_to_attribute_downshifts = 0xCC,
+			/** If the actors unarmed physical attacks ignore evasion */
+			easyrpg_ignore_evasion = 0xCD,
+			/** Hit rate of the actor on unarmed attacks */
+			easyrpg_unarmed_hit = 0xCE,
+			/** States inflicted by unarmed normal attacks of the actor */
+			easyrpg_unarmed_state_set_size = 0xCF,
+			/** States inflicted by unarmed normal attacks of the actor */
+			easyrpg_unarmed_state_set = 0xD0,
+			/** State infliction probability by unarmed normal attacks of the actor */
+			easyrpg_unarmed_state_chance = 0xD1,
+			/** Attributes used by unarmed normal attacks of the actor */
+			easyrpg_unarmed_attribute_set_size = 0xD2,
+			/** Attributes used by unarmed normal attacks of the actor */
+			easyrpg_unarmed_attribute_set = 0xD3,
+			/** If the actors unarmed physical attacks hits twice */
+			easyrpg_dual_attack = 0xD4,
+			/** If the actors unarmed physical targets the entire enemy party */
+			easyrpg_attack_all = 0xD5
 		};
 	};
 	struct ChunkSound {
@@ -239,7 +265,9 @@ namespace LDB_Reader {
 			/** If the row command should be enabled in RPG Maker 2003 battles */
 			easyrpg_enable_battle_row_command = 0xC9,
 			/** If alternative and gauge style battles should behave like traditional style battles */
-			easyrpg_sequential_order = 0xCA
+			easyrpg_sequential_order = 0xCA,
+			/** If the row feature should be disabled in RPG Maker 2003 games */
+			easyrpg_disable_row_feature = 0xCB
 		};
 	};
 	struct ChunkBattlerAnimation {
@@ -461,7 +489,19 @@ namespace LDB_Reader {
 			/** If the skill should bypass magic restrictions by states */
 			easyrpg_ignore_restrict_magic = 0xCE,
 			/** If the skill can absorb attack/defense/spirit/agility */
-			easyrpg_enable_stat_absorbing = 0xCF
+			easyrpg_enable_stat_absorbing = 0xCF,
+			/** If the skill should be affected by avoid attack states */
+			easyrpg_affected_by_evade_all_physical_attacks = 0xD0,
+			/** Critical hit rate percentage for the skill. If negative then the battler critical hit rate is used */
+			easyrpg_critical_hit_chance = 0xD1,
+			/** If the skill is affected by row modifiers */
+			easyrpg_affected_by_row_modifiers = 0xD2,
+			/** If the HP usage of the skill is a fixed number or in percent of the maximum HP */
+			easyrpg_hp_type = 0xD3,
+			/** How much percent of the maximum HP does the usage of the skill cost */
+			easyrpg_hp_percent = 0xD4,
+			/** How much HP does the usage of the skill cost */
+			easyrpg_hp_cost = 0xD5
 		};
 	};
 	struct ChunkItem {
@@ -662,8 +702,34 @@ namespace LDB_Reader {
 			attribute_ranks = 0x22,
 			/** Array - rpg::EnemyAction */
 			actions = 0x2A,
-			/** Animation for normal enemy attacks */
-			maniac_unarmed_animation = 0x0F
+			/** Animation for normal enemy attacks (Maniac Patch only) */
+			maniac_unarmed_animation = 0x0F,
+			/** Default AI behavior of the enemy */
+			easyrpg_enemyai = 0xC9,
+			/** If the enemy is protected against critical hits */
+			easyrpg_prevent_critical = 0xCA,
+			/** If the enemy has an increased evasion rate */
+			easyrpg_raise_evasion = 0xCB,
+			/** If the enemy is immune to attribute downshifts */
+			easyrpg_immune_to_attribute_downshifts = 0xCC,
+			/** If the enemies unarmed physical attacks ignore evasion */
+			easyrpg_ignore_evasion = 0xCD,
+			/** Hit rate of the enemy on normal attacks */
+			easyrpg_hit = 0xCE,
+			/** States inflicted by normal attacks of the enemy */
+			easyrpg_state_set_size = 0xCF,
+			/** States inflicted by normal attacks of the enemy */
+			easyrpg_state_set = 0xD0,
+			/** State infliction probability by normal attacks of the enemy */
+			easyrpg_state_chance = 0xD1,
+			/** Attributes used by normal attacks of the enemy */
+			easyrpg_attribute_set_size = 0xD2,
+			/** Attributes used by normal attacks of the enemy */
+			easyrpg_attribute_set = 0xD3,
+			/** If the enemies defend action quarters instead of halves HP damage */
+			easyrpg_super_guard = 0xD4,
+			/** If the enemies unarmed physical targets the entire player party */
+			easyrpg_attack_all = 0xD5
 		};
 	};
 	struct ChunkTroopMember {
@@ -821,7 +887,11 @@ namespace LDB_Reader {
 			/** Integer - RPG2003 */
 			grid_elongation = 0x2F,
 			/** Integer - RPG2003 */
-			grid_inclination = 0x30
+			grid_inclination = 0x30,
+			/** If the terrain damage is a percentage */
+			easyrpg_damage_in_percent = 0xC8,
+			/** If the terrain damage can kill the actors */
+			easyrpg_damage_can_kill = 0xC9
 		};
 	};
 	struct ChunkState {
@@ -909,7 +979,11 @@ namespace LDB_Reader {
 			/** Integer */
 			sp_change_map_steps = 0x43,
 			/** Integer */
-			sp_change_map_val = 0x44
+			sp_change_map_val = 0x44,
+			/** States cleared on infliction by this state */
+			easyrpg_immune_states_size = 0xC8,
+			/** States cleared on infliction by this state */
+			easyrpg_immune_states = 0xC9
 		};
 	};
 	struct ChunkTerms {
@@ -1387,7 +1461,17 @@ namespace LDB_Reader {
 			/** Absolute maximum value a base stat can have */
 			easyrpg_max_stat_base_value = 0xD5,
 			/** Absolute maximum value a battle stat can have */
-			easyrpg_max_stat_battle_value = 0xD6
+			easyrpg_max_stat_battle_value = 0xD6,
+			/** If the RPG Maker 2000 battle system should be used in RPG Maker 2003 games */
+			easyrpg_use_rpg2k_battle_system = 0xD7,
+			/** If RPG Maker 2000 battles in RPG Maker 2003 games should use the RPG2kE strings */
+			easyrpg_battle_use_rpg2ke_strings = 0xD8,
+			/** If the RPG Maker 2000 battle commands should be used in RPG Maker 2003 games */
+			easyrpg_use_rpg2k_battle_commands = 0xD9,
+			/** System default actor AI */
+			easyrpg_default_actorai = 0xDA,
+			/** System default enemy AI */
+			easyrpg_default_enemyai = 0xDB
 		};
 	};
 	struct ChunkSwitch {

--- a/src/generated/lcf/rpg/actor.h
+++ b/src/generated/lcf/rpg/actor.h
@@ -15,6 +15,7 @@
 // Headers
 #include <stdint.h>
 #include <vector>
+#include "lcf/dbbitarray.h"
 #include "lcf/dbstring.h"
 #include "lcf/rpg/equipment.h"
 #include "lcf/rpg/learning.h"
@@ -63,6 +64,17 @@ namespace rpg {
 		std::vector<uint8_t> state_ranks;
 		std::vector<uint8_t> attribute_ranks;
 		std::vector<int32_t> battle_commands;
+		int32_t easyrpg_actorai = -1;
+		bool easyrpg_prevent_critical = false;
+		bool easyrpg_raise_evasion = false;
+		bool easyrpg_immune_to_attribute_downshifts = false;
+		bool easyrpg_ignore_evasion = false;
+		int32_t easyrpg_unarmed_hit = -1;
+		DBBitArray easyrpg_unarmed_state_set;
+		int32_t easyrpg_unarmed_state_chance = 0;
+		DBBitArray easyrpg_unarmed_attribute_set;
+		bool easyrpg_dual_attack = false;
+		bool easyrpg_attack_all = false;
 	};
 
 	inline bool operator==(const Actor& l, const Actor& r) {
@@ -96,7 +108,18 @@ namespace rpg {
 		&& l.skill_name == r.skill_name
 		&& l.state_ranks == r.state_ranks
 		&& l.attribute_ranks == r.attribute_ranks
-		&& l.battle_commands == r.battle_commands;
+		&& l.battle_commands == r.battle_commands
+		&& l.easyrpg_actorai == r.easyrpg_actorai
+		&& l.easyrpg_prevent_critical == r.easyrpg_prevent_critical
+		&& l.easyrpg_raise_evasion == r.easyrpg_raise_evasion
+		&& l.easyrpg_immune_to_attribute_downshifts == r.easyrpg_immune_to_attribute_downshifts
+		&& l.easyrpg_ignore_evasion == r.easyrpg_ignore_evasion
+		&& l.easyrpg_unarmed_hit == r.easyrpg_unarmed_hit
+		&& l.easyrpg_unarmed_state_set == r.easyrpg_unarmed_state_set
+		&& l.easyrpg_unarmed_state_chance == r.easyrpg_unarmed_state_chance
+		&& l.easyrpg_unarmed_attribute_set == r.easyrpg_unarmed_attribute_set
+		&& l.easyrpg_dual_attack == r.easyrpg_dual_attack
+		&& l.easyrpg_attack_all == r.easyrpg_attack_all;
 	}
 
 	inline bool operator!=(const Actor& l, const Actor& r) {

--- a/src/generated/lcf/rpg/battlecommands.h
+++ b/src/generated/lcf/rpg/battlecommands.h
@@ -103,6 +103,7 @@ namespace rpg {
 		int32_t easyrpg_default_atb_mode = 0;
 		bool easyrpg_enable_battle_row_command = true;
 		bool easyrpg_sequential_order = false;
+		bool easyrpg_disable_row_feature = false;
 	};
 	inline std::ostream& operator<<(std::ostream& os, BattleCommands::Placement code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -147,7 +148,8 @@ namespace rpg {
 		&& l.death_teleport_face == r.death_teleport_face
 		&& l.easyrpg_default_atb_mode == r.easyrpg_default_atb_mode
 		&& l.easyrpg_enable_battle_row_command == r.easyrpg_enable_battle_row_command
-		&& l.easyrpg_sequential_order == r.easyrpg_sequential_order;
+		&& l.easyrpg_sequential_order == r.easyrpg_sequential_order
+		&& l.easyrpg_disable_row_feature == r.easyrpg_disable_row_feature;
 	}
 
 	inline bool operator!=(const BattleCommands& l, const BattleCommands& r) {

--- a/src/generated/lcf/rpg/enemy.h
+++ b/src/generated/lcf/rpg/enemy.h
@@ -15,6 +15,7 @@
 // Headers
 #include <stdint.h>
 #include <vector>
+#include "lcf/dbbitarray.h"
 #include "lcf/dbstring.h"
 #include "lcf/rpg/enemyaction.h"
 #include "lcf/context.h"
@@ -51,6 +52,17 @@ namespace rpg {
 		std::vector<uint8_t> attribute_ranks;
 		std::vector<EnemyAction> actions;
 		int32_t maniac_unarmed_animation = 1;
+		int32_t easyrpg_enemyai = -1;
+		bool easyrpg_prevent_critical = false;
+		bool easyrpg_raise_evasion = false;
+		bool easyrpg_immune_to_attribute_downshifts = false;
+		bool easyrpg_ignore_evasion = false;
+		int32_t easyrpg_hit = -1;
+		DBBitArray easyrpg_state_set;
+		int32_t easyrpg_state_chance = 0;
+		DBBitArray easyrpg_attribute_set;
+		bool easyrpg_super_guard = false;
+		bool easyrpg_attack_all = false;
 	};
 
 	inline bool operator==(const Enemy& l, const Enemy& r) {
@@ -75,7 +87,18 @@ namespace rpg {
 		&& l.state_ranks == r.state_ranks
 		&& l.attribute_ranks == r.attribute_ranks
 		&& l.actions == r.actions
-		&& l.maniac_unarmed_animation == r.maniac_unarmed_animation;
+		&& l.maniac_unarmed_animation == r.maniac_unarmed_animation
+		&& l.easyrpg_enemyai == r.easyrpg_enemyai
+		&& l.easyrpg_prevent_critical == r.easyrpg_prevent_critical
+		&& l.easyrpg_raise_evasion == r.easyrpg_raise_evasion
+		&& l.easyrpg_immune_to_attribute_downshifts == r.easyrpg_immune_to_attribute_downshifts
+		&& l.easyrpg_ignore_evasion == r.easyrpg_ignore_evasion
+		&& l.easyrpg_hit == r.easyrpg_hit
+		&& l.easyrpg_state_set == r.easyrpg_state_set
+		&& l.easyrpg_state_chance == r.easyrpg_state_chance
+		&& l.easyrpg_attribute_set == r.easyrpg_attribute_set
+		&& l.easyrpg_super_guard == r.easyrpg_super_guard
+		&& l.easyrpg_attack_all == r.easyrpg_attack_all;
 	}
 
 	inline bool operator!=(const Enemy& l, const Enemy& r) {

--- a/src/generated/lcf/rpg/skill.h
+++ b/src/generated/lcf/rpg/skill.h
@@ -70,6 +70,14 @@ namespace rpg {
 			"ally",
 			"party"
 		);
+		enum HpType {
+			HpType_cost = 0,
+			HpType_percent = 1
+		};
+		static constexpr auto kHpTypeTags = lcf::makeEnumTags<HpType>(
+			"cost",
+			"percent"
+		);
 
 		int ID = 0;
 		DBString name;
@@ -113,6 +121,12 @@ namespace rpg {
 		bool easyrpg_ignore_restrict_skill = false;
 		bool easyrpg_ignore_restrict_magic = false;
 		bool easyrpg_enable_stat_absorbing = false;
+		bool easyrpg_affected_by_evade_all_physical_attacks = false;
+		int32_t easyrpg_critical_hit_chance = 0;
+		bool easyrpg_affected_by_row_modifiers = false;
+		int32_t easyrpg_hp_type = 0;
+		int32_t easyrpg_hp_percent = 0;
+		int32_t easyrpg_hp_cost = 0;
 	};
 	inline std::ostream& operator<<(std::ostream& os, Skill::Type code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -123,6 +137,10 @@ namespace rpg {
 		return os;
 	}
 	inline std::ostream& operator<<(std::ostream& os, Skill::Scope code) {
+		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
+		return os;
+	}
+	inline std::ostream& operator<<(std::ostream& os, Skill::HpType code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
 		return os;
 	}
@@ -168,7 +186,13 @@ namespace rpg {
 		&& l.easyrpg_attribute_hit == r.easyrpg_attribute_hit
 		&& l.easyrpg_ignore_restrict_skill == r.easyrpg_ignore_restrict_skill
 		&& l.easyrpg_ignore_restrict_magic == r.easyrpg_ignore_restrict_magic
-		&& l.easyrpg_enable_stat_absorbing == r.easyrpg_enable_stat_absorbing;
+		&& l.easyrpg_enable_stat_absorbing == r.easyrpg_enable_stat_absorbing
+		&& l.easyrpg_affected_by_evade_all_physical_attacks == r.easyrpg_affected_by_evade_all_physical_attacks
+		&& l.easyrpg_critical_hit_chance == r.easyrpg_critical_hit_chance
+		&& l.easyrpg_affected_by_row_modifiers == r.easyrpg_affected_by_row_modifiers
+		&& l.easyrpg_hp_type == r.easyrpg_hp_type
+		&& l.easyrpg_hp_percent == r.easyrpg_hp_percent
+		&& l.easyrpg_hp_cost == r.easyrpg_hp_cost;
 	}
 
 	inline bool operator!=(const Skill& l, const Skill& r) {

--- a/src/generated/lcf/rpg/state.h
+++ b/src/generated/lcf/rpg/state.h
@@ -14,6 +14,7 @@
 
 // Headers
 #include <stdint.h>
+#include "lcf/dbbitarray.h"
 #include "lcf/dbstring.h"
 #include "lcf/enum_tags.h"
 #include "lcf/context.h"
@@ -114,6 +115,7 @@ namespace rpg {
 		int32_t sp_change_val = 0;
 		int32_t sp_change_map_steps = 0;
 		int32_t sp_change_map_val = 0;
+		DBBitArray easyrpg_immune_states;
 	};
 	inline std::ostream& operator<<(std::ostream& os, State::Persistence code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -174,7 +176,8 @@ namespace rpg {
 		&& l.sp_change_max == r.sp_change_max
 		&& l.sp_change_val == r.sp_change_val
 		&& l.sp_change_map_steps == r.sp_change_map_steps
-		&& l.sp_change_map_val == r.sp_change_map_val;
+		&& l.sp_change_map_val == r.sp_change_map_val
+		&& l.easyrpg_immune_states == r.easyrpg_immune_states;
 	}
 
 	inline bool operator!=(const State& l, const State& r) {

--- a/src/generated/lcf/rpg/system.h
+++ b/src/generated/lcf/rpg/system.h
@@ -246,6 +246,11 @@ namespace rpg {
 		int32_t easyrpg_max_enemy_sp = -1;
 		int32_t easyrpg_max_stat_base_value = -1;
 		int32_t easyrpg_max_stat_battle_value = -1;
+		bool easyrpg_use_rpg2k_battle_system = false;
+		bool easyrpg_battle_use_rpg2ke_strings = false;
+		bool easyrpg_use_rpg2k_battle_commands = false;
+		int32_t easyrpg_default_actorai = -1;
+		int32_t easyrpg_default_enemyai = -1;
 	};
 	inline std::ostream& operator<<(std::ostream& os, System::FadeOut code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -346,7 +351,12 @@ namespace rpg {
 		&& l.easyrpg_max_actor_sp == r.easyrpg_max_actor_sp
 		&& l.easyrpg_max_enemy_sp == r.easyrpg_max_enemy_sp
 		&& l.easyrpg_max_stat_base_value == r.easyrpg_max_stat_base_value
-		&& l.easyrpg_max_stat_battle_value == r.easyrpg_max_stat_battle_value;
+		&& l.easyrpg_max_stat_battle_value == r.easyrpg_max_stat_battle_value
+		&& l.easyrpg_use_rpg2k_battle_system == r.easyrpg_use_rpg2k_battle_system
+		&& l.easyrpg_battle_use_rpg2ke_strings == r.easyrpg_battle_use_rpg2ke_strings
+		&& l.easyrpg_use_rpg2k_battle_commands == r.easyrpg_use_rpg2k_battle_commands
+		&& l.easyrpg_default_actorai == r.easyrpg_default_actorai
+		&& l.easyrpg_default_enemyai == r.easyrpg_default_enemyai;
 	}
 
 	inline bool operator!=(const System& l, const System& r) {

--- a/src/generated/lcf/rpg/terrain.h
+++ b/src/generated/lcf/rpg/terrain.h
@@ -96,6 +96,8 @@ namespace rpg {
 		int32_t grid_top_y = 120;
 		int32_t grid_elongation = 392;
 		int32_t grid_inclination = 16000;
+		bool easyrpg_damage_in_percent = false;
+		bool easyrpg_damage_can_kill = false;
 	};
 	inline std::ostream& operator<<(std::ostream& os, Terrain::BushDepth code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -148,7 +150,9 @@ namespace rpg {
 		&& l.grid_location == r.grid_location
 		&& l.grid_top_y == r.grid_top_y
 		&& l.grid_elongation == r.grid_elongation
-		&& l.grid_inclination == r.grid_inclination;
+		&& l.grid_inclination == r.grid_inclination
+		&& l.easyrpg_damage_in_percent == r.easyrpg_damage_in_percent
+		&& l.easyrpg_damage_can_kill == r.easyrpg_damage_can_kill;
 	}
 
 	inline bool operator!=(const Terrain& l, const Terrain& r) {

--- a/src/generated/ldb_actor.cpp
+++ b/src/generated/ldb_actor.cpp
@@ -249,6 +249,95 @@ static TypedField<rpg::Actor, std::vector<int32_t>> static_battle_commands(
 	1,
 	1
 );
+static TypedField<rpg::Actor, int32_t> static_easyrpg_actorai(
+	&rpg::Actor::easyrpg_actorai,
+	LDB_Reader::ChunkActor::easyrpg_actorai,
+	"easyrpg_actorai",
+	0,
+	0
+);
+static TypedField<rpg::Actor, bool> static_easyrpg_prevent_critical(
+	&rpg::Actor::easyrpg_prevent_critical,
+	LDB_Reader::ChunkActor::easyrpg_prevent_critical,
+	"easyrpg_prevent_critical",
+	0,
+	0
+);
+static TypedField<rpg::Actor, bool> static_easyrpg_raise_evasion(
+	&rpg::Actor::easyrpg_raise_evasion,
+	LDB_Reader::ChunkActor::easyrpg_raise_evasion,
+	"easyrpg_raise_evasion",
+	0,
+	0
+);
+static TypedField<rpg::Actor, bool> static_easyrpg_immune_to_attribute_downshifts(
+	&rpg::Actor::easyrpg_immune_to_attribute_downshifts,
+	LDB_Reader::ChunkActor::easyrpg_immune_to_attribute_downshifts,
+	"easyrpg_immune_to_attribute_downshifts",
+	0,
+	0
+);
+static TypedField<rpg::Actor, bool> static_easyrpg_ignore_evasion(
+	&rpg::Actor::easyrpg_ignore_evasion,
+	LDB_Reader::ChunkActor::easyrpg_ignore_evasion,
+	"easyrpg_ignore_evasion",
+	0,
+	0
+);
+static TypedField<rpg::Actor, int32_t> static_easyrpg_unarmed_hit(
+	&rpg::Actor::easyrpg_unarmed_hit,
+	LDB_Reader::ChunkActor::easyrpg_unarmed_hit,
+	"easyrpg_unarmed_hit",
+	0,
+	0
+);
+static SizeField<rpg::Actor, DBBitArray> static_size_easyrpg_unarmed_state_set(
+	&rpg::Actor::easyrpg_unarmed_state_set,
+	LDB_Reader::ChunkActor::easyrpg_unarmed_state_set_size,
+	0,
+	0
+);
+static TypedField<rpg::Actor, DBBitArray> static_easyrpg_unarmed_state_set(
+	&rpg::Actor::easyrpg_unarmed_state_set,
+	LDB_Reader::ChunkActor::easyrpg_unarmed_state_set,
+	"easyrpg_unarmed_state_set",
+	1,
+	0
+);
+static TypedField<rpg::Actor, int32_t> static_easyrpg_unarmed_state_chance(
+	&rpg::Actor::easyrpg_unarmed_state_chance,
+	LDB_Reader::ChunkActor::easyrpg_unarmed_state_chance,
+	"easyrpg_unarmed_state_chance",
+	0,
+	0
+);
+static SizeField<rpg::Actor, DBBitArray> static_size_easyrpg_unarmed_attribute_set(
+	&rpg::Actor::easyrpg_unarmed_attribute_set,
+	LDB_Reader::ChunkActor::easyrpg_unarmed_attribute_set_size,
+	0,
+	0
+);
+static TypedField<rpg::Actor, DBBitArray> static_easyrpg_unarmed_attribute_set(
+	&rpg::Actor::easyrpg_unarmed_attribute_set,
+	LDB_Reader::ChunkActor::easyrpg_unarmed_attribute_set,
+	"easyrpg_unarmed_attribute_set",
+	1,
+	0
+);
+static TypedField<rpg::Actor, bool> static_easyrpg_dual_attack(
+	&rpg::Actor::easyrpg_dual_attack,
+	LDB_Reader::ChunkActor::easyrpg_dual_attack,
+	"easyrpg_dual_attack",
+	0,
+	0
+);
+static TypedField<rpg::Actor, bool> static_easyrpg_attack_all(
+	&rpg::Actor::easyrpg_attack_all,
+	LDB_Reader::ChunkActor::easyrpg_attack_all,
+	"easyrpg_attack_all",
+	0,
+	0
+);
 
 
 template <>
@@ -286,6 +375,19 @@ Field<rpg::Actor> const* Struct<rpg::Actor>::fields[] = {
 	&static_size_attribute_ranks,
 	&static_attribute_ranks,
 	&static_battle_commands,
+	&static_easyrpg_actorai,
+	&static_easyrpg_prevent_critical,
+	&static_easyrpg_raise_evasion,
+	&static_easyrpg_immune_to_attribute_downshifts,
+	&static_easyrpg_ignore_evasion,
+	&static_easyrpg_unarmed_hit,
+	&static_size_easyrpg_unarmed_state_set,
+	&static_easyrpg_unarmed_state_set,
+	&static_easyrpg_unarmed_state_chance,
+	&static_size_easyrpg_unarmed_attribute_set,
+	&static_easyrpg_unarmed_attribute_set,
+	&static_easyrpg_dual_attack,
+	&static_easyrpg_attack_all,
 	NULL
 };
 

--- a/src/generated/ldb_battlecommands.cpp
+++ b/src/generated/ldb_battlecommands.cpp
@@ -146,6 +146,13 @@ static TypedField<rpg::BattleCommands, bool> static_easyrpg_sequential_order(
 	0,
 	1
 );
+static TypedField<rpg::BattleCommands, bool> static_easyrpg_disable_row_feature(
+	&rpg::BattleCommands::easyrpg_disable_row_feature,
+	LDB_Reader::ChunkBattleCommands::easyrpg_disable_row_feature,
+	"easyrpg_disable_row_feature",
+	0,
+	1
+);
 
 
 template <>
@@ -168,6 +175,7 @@ Field<rpg::BattleCommands> const* Struct<rpg::BattleCommands>::fields[] = {
 	&static_easyrpg_default_atb_mode,
 	&static_easyrpg_enable_battle_row_command,
 	&static_easyrpg_sequential_order,
+	&static_easyrpg_disable_row_feature,
 	NULL
 };
 

--- a/src/generated/ldb_enemy.cpp
+++ b/src/generated/ldb_enemy.cpp
@@ -186,6 +186,95 @@ static TypedField<rpg::Enemy, int32_t> static_maniac_unarmed_animation(
 	0,
 	0
 );
+static TypedField<rpg::Enemy, int32_t> static_easyrpg_enemyai(
+	&rpg::Enemy::easyrpg_enemyai,
+	LDB_Reader::ChunkEnemy::easyrpg_enemyai,
+	"easyrpg_enemyai",
+	0,
+	0
+);
+static TypedField<rpg::Enemy, bool> static_easyrpg_prevent_critical(
+	&rpg::Enemy::easyrpg_prevent_critical,
+	LDB_Reader::ChunkEnemy::easyrpg_prevent_critical,
+	"easyrpg_prevent_critical",
+	0,
+	0
+);
+static TypedField<rpg::Enemy, bool> static_easyrpg_raise_evasion(
+	&rpg::Enemy::easyrpg_raise_evasion,
+	LDB_Reader::ChunkEnemy::easyrpg_raise_evasion,
+	"easyrpg_raise_evasion",
+	0,
+	0
+);
+static TypedField<rpg::Enemy, bool> static_easyrpg_immune_to_attribute_downshifts(
+	&rpg::Enemy::easyrpg_immune_to_attribute_downshifts,
+	LDB_Reader::ChunkEnemy::easyrpg_immune_to_attribute_downshifts,
+	"easyrpg_immune_to_attribute_downshifts",
+	0,
+	0
+);
+static TypedField<rpg::Enemy, bool> static_easyrpg_ignore_evasion(
+	&rpg::Enemy::easyrpg_ignore_evasion,
+	LDB_Reader::ChunkEnemy::easyrpg_ignore_evasion,
+	"easyrpg_ignore_evasion",
+	0,
+	0
+);
+static TypedField<rpg::Enemy, int32_t> static_easyrpg_hit(
+	&rpg::Enemy::easyrpg_hit,
+	LDB_Reader::ChunkEnemy::easyrpg_hit,
+	"easyrpg_hit",
+	0,
+	0
+);
+static SizeField<rpg::Enemy, DBBitArray> static_size_easyrpg_state_set(
+	&rpg::Enemy::easyrpg_state_set,
+	LDB_Reader::ChunkEnemy::easyrpg_state_set_size,
+	0,
+	0
+);
+static TypedField<rpg::Enemy, DBBitArray> static_easyrpg_state_set(
+	&rpg::Enemy::easyrpg_state_set,
+	LDB_Reader::ChunkEnemy::easyrpg_state_set,
+	"easyrpg_state_set",
+	1,
+	0
+);
+static TypedField<rpg::Enemy, int32_t> static_easyrpg_state_chance(
+	&rpg::Enemy::easyrpg_state_chance,
+	LDB_Reader::ChunkEnemy::easyrpg_state_chance,
+	"easyrpg_state_chance",
+	0,
+	0
+);
+static SizeField<rpg::Enemy, DBBitArray> static_size_easyrpg_attribute_set(
+	&rpg::Enemy::easyrpg_attribute_set,
+	LDB_Reader::ChunkEnemy::easyrpg_attribute_set_size,
+	0,
+	0
+);
+static TypedField<rpg::Enemy, DBBitArray> static_easyrpg_attribute_set(
+	&rpg::Enemy::easyrpg_attribute_set,
+	LDB_Reader::ChunkEnemy::easyrpg_attribute_set,
+	"easyrpg_attribute_set",
+	1,
+	0
+);
+static TypedField<rpg::Enemy, bool> static_easyrpg_super_guard(
+	&rpg::Enemy::easyrpg_super_guard,
+	LDB_Reader::ChunkEnemy::easyrpg_super_guard,
+	"easyrpg_super_guard",
+	0,
+	0
+);
+static TypedField<rpg::Enemy, bool> static_easyrpg_attack_all(
+	&rpg::Enemy::easyrpg_attack_all,
+	LDB_Reader::ChunkEnemy::easyrpg_attack_all,
+	"easyrpg_attack_all",
+	0,
+	0
+);
 
 
 template <>
@@ -214,6 +303,19 @@ Field<rpg::Enemy> const* Struct<rpg::Enemy>::fields[] = {
 	&static_attribute_ranks,
 	&static_actions,
 	&static_maniac_unarmed_animation,
+	&static_easyrpg_enemyai,
+	&static_easyrpg_prevent_critical,
+	&static_easyrpg_raise_evasion,
+	&static_easyrpg_immune_to_attribute_downshifts,
+	&static_easyrpg_ignore_evasion,
+	&static_easyrpg_hit,
+	&static_size_easyrpg_state_set,
+	&static_easyrpg_state_set,
+	&static_easyrpg_state_chance,
+	&static_size_easyrpg_attribute_set,
+	&static_easyrpg_attribute_set,
+	&static_easyrpg_super_guard,
+	&static_easyrpg_attack_all,
 	NULL
 };
 

--- a/src/generated/ldb_skill.cpp
+++ b/src/generated/ldb_skill.cpp
@@ -319,6 +319,48 @@ static TypedField<rpg::Skill, bool> static_easyrpg_enable_stat_absorbing(
 	0,
 	0
 );
+static TypedField<rpg::Skill, bool> static_easyrpg_affected_by_evade_all_physical_attacks(
+	&rpg::Skill::easyrpg_affected_by_evade_all_physical_attacks,
+	LDB_Reader::ChunkSkill::easyrpg_affected_by_evade_all_physical_attacks,
+	"easyrpg_affected_by_evade_all_physical_attacks",
+	0,
+	1
+);
+static TypedField<rpg::Skill, int32_t> static_easyrpg_critical_hit_chance(
+	&rpg::Skill::easyrpg_critical_hit_chance,
+	LDB_Reader::ChunkSkill::easyrpg_critical_hit_chance,
+	"easyrpg_critical_hit_chance",
+	0,
+	0
+);
+static TypedField<rpg::Skill, bool> static_easyrpg_affected_by_row_modifiers(
+	&rpg::Skill::easyrpg_affected_by_row_modifiers,
+	LDB_Reader::ChunkSkill::easyrpg_affected_by_row_modifiers,
+	"easyrpg_affected_by_row_modifiers",
+	0,
+	1
+);
+static TypedField<rpg::Skill, int32_t> static_easyrpg_hp_type(
+	&rpg::Skill::easyrpg_hp_type,
+	LDB_Reader::ChunkSkill::easyrpg_hp_type,
+	"easyrpg_hp_type",
+	0,
+	1
+);
+static TypedField<rpg::Skill, int32_t> static_easyrpg_hp_percent(
+	&rpg::Skill::easyrpg_hp_percent,
+	LDB_Reader::ChunkSkill::easyrpg_hp_percent,
+	"easyrpg_hp_percent",
+	0,
+	1
+);
+static TypedField<rpg::Skill, int32_t> static_easyrpg_hp_cost(
+	&rpg::Skill::easyrpg_hp_cost,
+	LDB_Reader::ChunkSkill::easyrpg_hp_cost,
+	"easyrpg_hp_cost",
+	0,
+	0
+);
 
 
 template <>
@@ -366,6 +408,12 @@ Field<rpg::Skill> const* Struct<rpg::Skill>::fields[] = {
 	&static_easyrpg_ignore_restrict_skill,
 	&static_easyrpg_ignore_restrict_magic,
 	&static_easyrpg_enable_stat_absorbing,
+	&static_easyrpg_affected_by_evade_all_physical_attacks,
+	&static_easyrpg_critical_hit_chance,
+	&static_easyrpg_affected_by_row_modifiers,
+	&static_easyrpg_hp_type,
+	&static_easyrpg_hp_percent,
+	&static_easyrpg_hp_cost,
 	NULL
 };
 

--- a/src/generated/ldb_state.cpp
+++ b/src/generated/ldb_state.cpp
@@ -314,6 +314,19 @@ static TypedField<rpg::State, int32_t> static_sp_change_map_val(
 	0,
 	0
 );
+static SizeField<rpg::State, DBBitArray> static_size_easyrpg_immune_states(
+	&rpg::State::easyrpg_immune_states,
+	LDB_Reader::ChunkState::easyrpg_immune_states_size,
+	0,
+	0
+);
+static TypedField<rpg::State, DBBitArray> static_easyrpg_immune_states(
+	&rpg::State::easyrpg_immune_states,
+	LDB_Reader::ChunkState::easyrpg_immune_states,
+	"easyrpg_immune_states",
+	1,
+	0
+);
 
 
 template <>
@@ -360,6 +373,8 @@ Field<rpg::State> const* Struct<rpg::State>::fields[] = {
 	&static_sp_change_val,
 	&static_sp_change_map_steps,
 	&static_sp_change_map_val,
+	&static_size_easyrpg_immune_states,
+	&static_easyrpg_immune_states,
 	NULL
 };
 

--- a/src/generated/ldb_system.cpp
+++ b/src/generated/ldb_system.cpp
@@ -522,6 +522,41 @@ static TypedField<rpg::System, int32_t> static_easyrpg_max_stat_battle_value(
 	0,
 	0
 );
+static TypedField<rpg::System, bool> static_easyrpg_use_rpg2k_battle_system(
+	&rpg::System::easyrpg_use_rpg2k_battle_system,
+	LDB_Reader::ChunkSystem::easyrpg_use_rpg2k_battle_system,
+	"easyrpg_use_rpg2k_battle_system",
+	0,
+	1
+);
+static TypedField<rpg::System, bool> static_easyrpg_battle_use_rpg2ke_strings(
+	&rpg::System::easyrpg_battle_use_rpg2ke_strings,
+	LDB_Reader::ChunkSystem::easyrpg_battle_use_rpg2ke_strings,
+	"easyrpg_battle_use_rpg2ke_strings",
+	0,
+	1
+);
+static TypedField<rpg::System, bool> static_easyrpg_use_rpg2k_battle_commands(
+	&rpg::System::easyrpg_use_rpg2k_battle_commands,
+	LDB_Reader::ChunkSystem::easyrpg_use_rpg2k_battle_commands,
+	"easyrpg_use_rpg2k_battle_commands",
+	0,
+	1
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_default_actorai(
+	&rpg::System::easyrpg_default_actorai,
+	LDB_Reader::ChunkSystem::easyrpg_default_actorai,
+	"easyrpg_default_actorai",
+	0,
+	0
+);
+static TypedField<rpg::System, int32_t> static_easyrpg_default_enemyai(
+	&rpg::System::easyrpg_default_enemyai,
+	LDB_Reader::ChunkSystem::easyrpg_default_enemyai,
+	"easyrpg_default_enemyai",
+	0,
+	0
+);
 
 
 template <>
@@ -598,6 +633,11 @@ Field<rpg::System> const* Struct<rpg::System>::fields[] = {
 	&static_easyrpg_max_enemy_sp,
 	&static_easyrpg_max_stat_base_value,
 	&static_easyrpg_max_stat_battle_value,
+	&static_easyrpg_use_rpg2k_battle_system,
+	&static_easyrpg_battle_use_rpg2ke_strings,
+	&static_easyrpg_use_rpg2k_battle_commands,
+	&static_easyrpg_default_actorai,
+	&static_easyrpg_default_enemyai,
 	NULL
 };
 

--- a/src/generated/ldb_terrain.cpp
+++ b/src/generated/ldb_terrain.cpp
@@ -244,6 +244,20 @@ static TypedField<rpg::Terrain, int32_t> static_grid_inclination(
 	0,
 	1
 );
+static TypedField<rpg::Terrain, bool> static_easyrpg_damage_in_percent(
+	&rpg::Terrain::easyrpg_damage_in_percent,
+	LDB_Reader::ChunkTerrain::easyrpg_damage_in_percent,
+	"easyrpg_damage_in_percent",
+	0,
+	0
+);
+static TypedField<rpg::Terrain, bool> static_easyrpg_damage_can_kill(
+	&rpg::Terrain::easyrpg_damage_can_kill,
+	LDB_Reader::ChunkTerrain::easyrpg_damage_can_kill,
+	"easyrpg_damage_can_kill",
+	0,
+	0
+);
 
 
 template <>
@@ -280,6 +294,8 @@ Field<rpg::Terrain> const* Struct<rpg::Terrain>::fields[] = {
 	&static_grid_top_y,
 	&static_grid_elongation,
 	&static_grid_inclination,
+	&static_easyrpg_damage_in_percent,
+	&static_easyrpg_damage_can_kill,
 	NULL
 };
 

--- a/src/generated/rpg_actor.cpp
+++ b/src/generated/rpg_actor.cpp
@@ -64,6 +64,25 @@ std::ostream& operator<<(std::ostream& os, const Actor& obj) {
 		os << (i == 0 ? "[" : ", ") << obj.battle_commands[i];
 	}
 	os << "]";
+	os << ", easyrpg_actorai="<< obj.easyrpg_actorai;
+	os << ", easyrpg_prevent_critical="<< obj.easyrpg_prevent_critical;
+	os << ", easyrpg_raise_evasion="<< obj.easyrpg_raise_evasion;
+	os << ", easyrpg_immune_to_attribute_downshifts="<< obj.easyrpg_immune_to_attribute_downshifts;
+	os << ", easyrpg_ignore_evasion="<< obj.easyrpg_ignore_evasion;
+	os << ", easyrpg_unarmed_hit="<< obj.easyrpg_unarmed_hit;
+	os << ", easyrpg_unarmed_state_set=";
+	for (size_t i = 0; i < obj.easyrpg_unarmed_state_set.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.easyrpg_unarmed_state_set[i];
+	}
+	os << "]";
+	os << ", easyrpg_unarmed_state_chance="<< obj.easyrpg_unarmed_state_chance;
+	os << ", easyrpg_unarmed_attribute_set=";
+	for (size_t i = 0; i < obj.easyrpg_unarmed_attribute_set.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.easyrpg_unarmed_attribute_set[i];
+	}
+	os << "]";
+	os << ", easyrpg_dual_attack="<< obj.easyrpg_dual_attack;
+	os << ", easyrpg_attack_all="<< obj.easyrpg_attack_all;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_battlecommands.cpp
+++ b/src/generated/rpg_battlecommands.cpp
@@ -39,6 +39,7 @@ std::ostream& operator<<(std::ostream& os, const BattleCommands& obj) {
 	os << ", easyrpg_default_atb_mode="<< obj.easyrpg_default_atb_mode;
 	os << ", easyrpg_enable_battle_row_command="<< obj.easyrpg_enable_battle_row_command;
 	os << ", easyrpg_sequential_order="<< obj.easyrpg_sequential_order;
+	os << ", easyrpg_disable_row_feature="<< obj.easyrpg_disable_row_feature;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_enemy.cpp
+++ b/src/generated/rpg_enemy.cpp
@@ -51,6 +51,25 @@ std::ostream& operator<<(std::ostream& os, const Enemy& obj) {
 	}
 	os << "]";
 	os << ", maniac_unarmed_animation="<< obj.maniac_unarmed_animation;
+	os << ", easyrpg_enemyai="<< obj.easyrpg_enemyai;
+	os << ", easyrpg_prevent_critical="<< obj.easyrpg_prevent_critical;
+	os << ", easyrpg_raise_evasion="<< obj.easyrpg_raise_evasion;
+	os << ", easyrpg_immune_to_attribute_downshifts="<< obj.easyrpg_immune_to_attribute_downshifts;
+	os << ", easyrpg_ignore_evasion="<< obj.easyrpg_ignore_evasion;
+	os << ", easyrpg_hit="<< obj.easyrpg_hit;
+	os << ", easyrpg_state_set=";
+	for (size_t i = 0; i < obj.easyrpg_state_set.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.easyrpg_state_set[i];
+	}
+	os << "]";
+	os << ", easyrpg_state_chance="<< obj.easyrpg_state_chance;
+	os << ", easyrpg_attribute_set=";
+	for (size_t i = 0; i < obj.easyrpg_attribute_set.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.easyrpg_attribute_set[i];
+	}
+	os << "]";
+	os << ", easyrpg_super_guard="<< obj.easyrpg_super_guard;
+	os << ", easyrpg_attack_all="<< obj.easyrpg_attack_all;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_enums.cpp
+++ b/src/generated/rpg_enums.cpp
@@ -63,6 +63,7 @@ constexpr decltype(Chipset::kAnimTypeTags) Chipset::kAnimTypeTags;
 constexpr decltype(Skill::kTypeTags) Skill::kTypeTags;
 constexpr decltype(Skill::kSpTypeTags) Skill::kSpTypeTags;
 constexpr decltype(Skill::kScopeTags) Skill::kScopeTags;
+constexpr decltype(Skill::kHpTypeTags) Skill::kHpTypeTags;
 constexpr decltype(Item::kTypeTags) Item::kTypeTags;
 constexpr decltype(Item::kTrajectoryTags) Item::kTrajectoryTags;
 constexpr decltype(Item::kTargetTags) Item::kTargetTags;

--- a/src/generated/rpg_skill.cpp
+++ b/src/generated/rpg_skill.cpp
@@ -71,6 +71,12 @@ std::ostream& operator<<(std::ostream& os, const Skill& obj) {
 	os << ", easyrpg_ignore_restrict_skill="<< obj.easyrpg_ignore_restrict_skill;
 	os << ", easyrpg_ignore_restrict_magic="<< obj.easyrpg_ignore_restrict_magic;
 	os << ", easyrpg_enable_stat_absorbing="<< obj.easyrpg_enable_stat_absorbing;
+	os << ", easyrpg_affected_by_evade_all_physical_attacks="<< obj.easyrpg_affected_by_evade_all_physical_attacks;
+	os << ", easyrpg_critical_hit_chance="<< obj.easyrpg_critical_hit_chance;
+	os << ", easyrpg_affected_by_row_modifiers="<< obj.easyrpg_affected_by_row_modifiers;
+	os << ", easyrpg_hp_type="<< obj.easyrpg_hp_type;
+	os << ", easyrpg_hp_percent="<< obj.easyrpg_hp_percent;
+	os << ", easyrpg_hp_cost="<< obj.easyrpg_hp_cost;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_state.cpp
+++ b/src/generated/rpg_state.cpp
@@ -60,6 +60,11 @@ std::ostream& operator<<(std::ostream& os, const State& obj) {
 	os << ", sp_change_val="<< obj.sp_change_val;
 	os << ", sp_change_map_steps="<< obj.sp_change_map_steps;
 	os << ", sp_change_map_val="<< obj.sp_change_map_val;
+	os << ", easyrpg_immune_states=";
+	for (size_t i = 0; i < obj.easyrpg_immune_states.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.easyrpg_immune_states[i];
+	}
+	os << "]";
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_system.cpp
+++ b/src/generated/rpg_system.cpp
@@ -103,6 +103,11 @@ std::ostream& operator<<(std::ostream& os, const System& obj) {
 	os << ", easyrpg_max_enemy_sp="<< obj.easyrpg_max_enemy_sp;
 	os << ", easyrpg_max_stat_base_value="<< obj.easyrpg_max_stat_base_value;
 	os << ", easyrpg_max_stat_battle_value="<< obj.easyrpg_max_stat_battle_value;
+	os << ", easyrpg_use_rpg2k_battle_system="<< obj.easyrpg_use_rpg2k_battle_system;
+	os << ", easyrpg_battle_use_rpg2ke_strings="<< obj.easyrpg_battle_use_rpg2ke_strings;
+	os << ", easyrpg_use_rpg2k_battle_commands="<< obj.easyrpg_use_rpg2k_battle_commands;
+	os << ", easyrpg_default_actorai="<< obj.easyrpg_default_actorai;
+	os << ", easyrpg_default_enemyai="<< obj.easyrpg_default_enemyai;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_terrain.cpp
+++ b/src/generated/rpg_terrain.cpp
@@ -57,6 +57,8 @@ std::ostream& operator<<(std::ostream& os, const Terrain& obj) {
 	os << ", grid_top_y="<< obj.grid_top_y;
 	os << ", grid_elongation="<< obj.grid_elongation;
 	os << ", grid_inclination="<< obj.grid_inclination;
+	os << ", easyrpg_damage_in_percent="<< obj.easyrpg_damage_in_percent;
+	os << ", easyrpg_damage_can_kill="<< obj.easyrpg_damage_can_kill;
 	os << "}";
 	return os;
 }


### PR DESCRIPTION
This PR adds the following database settings, here we can discuss which ones are useful for inclusion. If some options are unclear, then ask away!
- BattleCommands option 203: Disable RPG Maker 2003 row feature
- Actor option 201: Custom Actor AI behavior
- Actor option 202: Protected against critical hits
- Actor option 203: Increased physical attack evasion rate
- Actor option 204: Immune to attribute downshifts
- Actor option 205: Ignore enemy evasion on physical attacks
- Actor option 206: Unarmed attack hit rate
- Actor options 207 and 208: States inflicted by unarmed normal attacks
- Actor option 209: State infliction probability by unarmed normal attacks
- Actor options 210 and 211: Attributes used by unarmed normal attacks
- Actor option 212: Unarmed attack dual attack
- Actor option 213: Unarmed attack targets entire enemy party
- Enemy option 201: Custom Enemy AI behavior
- Enemy option 202: Protected against critical hits
- Enemy option 203: Increased physical attack evasion rate
- Enemy option 204: Immune to attribute downshifts
- Enemy option 205: Ignore enemy evasion on physical attacks
- Enemy option 206: Normal attack hit rate
- Enemy options 207 and 208: States inflicted by normal attacks
- Enemy option 209: State infliction probability by normal attacks
- Enemy options 210 and 211: Attributes used by normal attacks
- Enemy option 212: Quarter instead of half damage on defend action
- Enemy option 213: Normal attack targets entire player party
- Skill option 208: Affected by avoid attack states
- Skill option 209: Critical hit rate percentage
- Skill option 210: Affected by row modifiers
- Skill option 211: Skill HP cost type
- Skill option 212: Skill HP cost in percent of the maximum HP
- Skill option 213: Skill fixed value HP cost
- State options 200 and 201: Clear certain states on infliction by this state
- Terrain option 200: Damage in percent of the actor HP
- Terrain option 201: Damage can kill the actor
- System option 215: Use RPG Maker 2000 battle system in RPG Maker 2003 games
- System option 216: Use RPG2kE strings in RPG Maker 2000 battles in RPG Maker 2003 games
- System option 217: Use RPG Maker 2000 battle commands in RPG Maker 2003 games
- System option 218: Default autobattle AI
- System option 219: Default enemy AI

The implementation of the features can be found at [Player#2697](https://github.com/EasyRPG/Player/pull/2697).