### PR TITLE
Improve encoding detection

### DIFF
--- a/src/lcf/ldb/reader.h
+++ b/src/lcf/ldb/reader.h
@@ -30,32 +30,32 @@ namespace LDB_Reader {
 	/**
 	 * Loads Database.
 	 */
-	std::unique_ptr<lcf::rpg::Database> Load(const std::string& filename, const std::string& encoding);
+	std::unique_ptr<lcf::rpg::Database> Load(StringView filename, StringView encoding = "");
 
 	/**
 	 * Saves Database.
 	 */
-	bool Save(const std::string& filename, const lcf::rpg::Database& db, const std::string& encoding, SaveOpt opt = SaveOpt::eNone);
+	bool Save(StringView filename, const lcf::rpg::Database& db, StringView encoding = "", SaveOpt opt = SaveOpt::eNone);
 
 	/**
 	 * Saves Database as XML.
 	 */
-	bool SaveXml(const std::string& filename, const lcf::rpg::Database& db);
+	bool SaveXml(StringView filename, const lcf::rpg::Database& db);
 
 	/**
 	 * Load Database as XML.
 	 */
-	std::unique_ptr<lcf::rpg::Database> LoadXml(const std::string& filename);
+	std::unique_ptr<lcf::rpg::Database> LoadXml(StringView filename);
 
 	/**
 	 * Loads Database.
 	 */
-	std::unique_ptr<lcf::rpg::Database> Load(std::istream& filestream, const std::string& encoding);
+	std::unique_ptr<lcf::rpg::Database> Load(std::istream& filestream, StringView encoding = "");
 
 	/**
 	 * Saves Database.
 	 */
-	bool Save(std::ostream& filestream, const lcf::rpg::Database& db, const std::string& encoding, SaveOpt opt = SaveOpt::eNone);
+	bool Save(std::ostream& filestream, const lcf::rpg::Database& db, StringView encoding = "", SaveOpt opt = SaveOpt::eNone);
 
 	/**
 	 * Saves Database as XML.

--- a/src/lcf/lmt/reader.h
+++ b/src/lcf/lmt/reader.h
@@ -25,32 +25,32 @@ namespace LMT_Reader {
 	/**
 	 * Loads Map Tree.
 	 */
-	std::unique_ptr<lcf::rpg::TreeMap> Load(const std::string& filename, const std::string &encoding);
+	std::unique_ptr<lcf::rpg::TreeMap> Load(StringView filename, StringView encoding = "");
 
 	/**
 	 * Saves Map Tree.
 	 */
-	bool Save(const std::string& filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine, const std::string &encoding, SaveOpt opt = SaveOpt::eNone);
+	bool Save(StringView filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine, StringView encoding = "", SaveOpt opt = SaveOpt::eNone);
 
 	/**
 	 * Saves Map Tree as XML.
 	 */
-	bool SaveXml(const std::string& filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine);
+	bool SaveXml(StringView filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine);
 
 	/**
 	 * Loads Map Tree as XML.
 	 */
-	std::unique_ptr<lcf::rpg::TreeMap> LoadXml(const std::string& filename);
+	std::unique_ptr<lcf::rpg::TreeMap> LoadXml(StringView filename);
 
 	/**
 	 * Loads Map Tree.
 	 */
-	std::unique_ptr<lcf::rpg::TreeMap> Load(std::istream& filestream, const std::string &encoding);
+	std::unique_ptr<lcf::rpg::TreeMap> Load(std::istream& filestream, StringView encoding = "");
 
 	/**
 	 * Saves Map Tree.
 	 */
-	bool Save(std::ostream& filestream, const lcf::rpg::TreeMap& tmap, EngineVersion engine, const std::string &encoding, SaveOpt opt = SaveOpt::eNone);
+	bool Save(std::ostream& filestream, const lcf::rpg::TreeMap& tmap, EngineVersion engine, StringView encoding = "", SaveOpt opt = SaveOpt::eNone);
 
 	/**
 	 * Saves Map Tree as XML.

--- a/src/lcf/lmu/reader.h
+++ b/src/lcf/lmu/reader.h
@@ -30,32 +30,32 @@ namespace LMU_Reader {
 	/**
 	 * Loads map.
 	 */
-	std::unique_ptr<rpg::Map> Load(const std::string& filename, const std::string& encoding);
+	std::unique_ptr<rpg::Map> Load(StringView filename, StringView encoding = "");
 
 	/**
 	 * Saves map.
 	 */
-	bool Save(const std::string& filename, const rpg::Map& map, EngineVersion engine, const std::string& encoding, SaveOpt opt = SaveOpt::eNone);
+	bool Save(StringView filename, const rpg::Map& map, EngineVersion engine, StringView encoding = "", SaveOpt opt = SaveOpt::eNone);
 
 	/**
 	 * Saves map as XML.
 	 */
-	bool SaveXml(const std::string& filename, const rpg::Map& map, EngineVersion engine);
+	bool SaveXml(StringView filename, const rpg::Map& map, EngineVersion engine);
 
 	/**
 	 * Loads map as XML.
 	 */
-	std::unique_ptr<rpg::Map> LoadXml(const std::string& filename);
+	std::unique_ptr<rpg::Map> LoadXml(StringView filename);
 
 	/**
 	 * Loads map.
 	 */
-	std::unique_ptr<rpg::Map> Load(std::istream& filestream, const std::string& encoding);
+	std::unique_ptr<rpg::Map> Load(std::istream& filestream, StringView encoding = "");
 
 	/**
 	 * Saves map.
 	 */
-	bool Save(std::ostream& filestream, const rpg::Map& map, EngineVersion engine, const std::string& encoding, SaveOpt opt = SaveOpt::eNone);
+	bool Save(std::ostream& filestream, const rpg::Map& map, EngineVersion engine, StringView encoding = "", SaveOpt opt = SaveOpt::eNone);
 
 	/**
 	 * Saves map as XML.

--- a/src/lcf/lsd/reader.h
+++ b/src/lcf/lsd/reader.h
@@ -27,17 +27,17 @@ namespace LSD_Reader {
 	/**
 	 * Converts from UNIX timestamp to Delphi's TDateTime format.
 	 */
-	double ToTDateTime(std::time_t const t);
+	double ToTDateTime(std::time_t t);
 
 	/**
 	 * Converts from Delphi's TDateTime format to UNIX timestamp.
 	 */
-	std::time_t ToUnixTimestamp(double const ms);
+	std::time_t ToUnixTimestamp(double ms);
 
 	/**
 	 * Returns current system time encoded in Delphi's TDateTime format.
 	 */
-	double GenerateTimestamp(std::time_t const t = std::time(NULL));
+	double GenerateTimestamp(std::time_t t = std::time(nullptr));
 
 	/**
 	 * Increment the save save_count and update the timestamp.
@@ -47,32 +47,32 @@ namespace LSD_Reader {
 	/**
 	 * Loads Savegame.
 	 */
-	std::unique_ptr<rpg::Save> Load(const std::string& filename, const std::string &encoding);
+	std::unique_ptr<rpg::Save> Load(StringView filename, StringView encoding = "");
 
 	/**
 	 * Saves Savegame.
 	 */
-	bool Save(const std::string& filename, const rpg::Save& save, EngineVersion engine, const std::string &encoding);
+	bool Save(StringView filename, const rpg::Save& save, EngineVersion engine, StringView encoding = "");
 
 	/*
 	 * Saves Savegame as XML.
 	 */
-	bool SaveXml(const std::string& filename, const rpg::Save& save, EngineVersion engine);
+	bool SaveXml(StringView filename, const rpg::Save& save, EngineVersion engine);
 
 	/**
 	 * Loads Savegame as XML.
 	 */
-	std::unique_ptr<rpg::Save> LoadXml(const std::string& filename);
+	std::unique_ptr<rpg::Save> LoadXml(StringView filename);
 
 	/**
 	 * Loads Savegame.
 	 */
-	std::unique_ptr<rpg::Save> Load(std::istream& filestream, const std::string &encoding);
+	std::unique_ptr<rpg::Save> Load(std::istream& filestream, StringView encoding = "");
 
 	/**
 	 * Saves Savegame.
 	 */
-	bool Save(std::ostream& filestream, const rpg::Save& save, EngineVersion engine, const std::string &encoding);
+	bool Save(std::ostream& filestream, const rpg::Save& save, EngineVersion engine, StringView encoding = "");
 
 	/*
 	 * Saves Savegame as XML.

--- a/src/lcf/reader_lcf.h
+++ b/src/lcf/reader_lcf.h
@@ -38,12 +38,7 @@ public:
 	 * @param filestream already opened filestream.
 	 * @param encoding name of the encoding.
 	 */
-	LcfReader(std::istream& filestream, std::string encoding = "");
-
-	/**
-	 * Destructor. Closes the opened file.
-	 */
-	~LcfReader();
+	explicit LcfReader(std::istream& filestream, std::string encoding = "");
 
 	/**
 	 * Returns the last set error.

--- a/src/lcf/reader_util.h
+++ b/src/lcf/reader_util.h
@@ -15,6 +15,9 @@
 #include "lcf/string_view.h"
 
 namespace lcf {
+namespace rpg {
+	class Database;
+}
 
 /**
  * ReaderUtil namespace.
@@ -29,42 +32,42 @@ namespace ReaderUtil {
 	std::string CodepageToEncoding(int codepage);
 
 	/**
-	 * Detects the encoding based on text analysis.
+	 * Detects the encoding of the database based on text analysis.
 	 *
-	 * @param filestream stream containing the database file
+	 * @param db Database to process
 	 *
 	 * @return encoding or empty string if not detected.
 	 */
-	std::string DetectEncoding(std::istream& filestream);
+	std::string DetectEncoding(lcf::rpg::Database& db);
 
 	/**
-	 * Detects the encoding based on text analysis.
+	 * Detects the encoding of the database based on text analysis.
+	 * Returns a vector of possible candidates, highest candidate being at the beginning.
 	 *
-	 * @param filestream stream containing the database file
+	 * @param db Database to process
+	 *
+	 * @return list of encodings or empty if not detected
+	 */
+	std::vector<std::string> DetectEncodings(lcf::rpg::Database& db);
+
+	/**
+	 * Detects the encoding of a string based on text analysis.
+	 *
+	 * @param string encoded data of a few hundred bytes
 	 *
 	 * @return encoding or empty string if not detected.
 	 */
 	std::string DetectEncoding(StringView data);
 
 	/**
-	 * Detects the encoding based on text analysis and returns a vector with
-	 * possible candidates, highest candidate being at the beginning.
-	 *
-	 * @param filestream stream containing the database file
-	 *
-	 * @return list of encodings or empty if not detected
-	 */
-	std::vector<std::string> DetectEncodings(std::istream& filestream);
-
-	/**
-	 * Detects the encoding based on text analysis and returns a vector with
-	 * possible candidates, highest candidate being at the beginning.
+	 * Detects the encoding of a string based on text analysis.
+	 * Returns a vector of possible candidates, highest candidate being at the beginning.
 	 *
 	 * @param string encoded data of a few hundred bytes
 	 *
 	 * @return list of encodings or empty if not detected
 	 */
-	std::vector<std::string> DetectEncodings(StringView data);
+	std::vector<std::string> DetectEncodings(StringView string);
 
 	/**
 	 * Returns the encoding set in the ini file.
@@ -73,7 +76,7 @@ namespace ReaderUtil {
 	 *
 	 * @return encoding or empty string if not found.
 	 */
-	std::string GetEncoding(const std::string& ini_file);
+	std::string GetEncoding(StringView ini_file);
 
 	/**
 	 * Returns the encoding set in the ini file.

--- a/src/lcf/writer_lcf.h
+++ b/src/lcf/writer_lcf.h
@@ -43,11 +43,6 @@ public:
 	LcfWriter(std::ostream& filestream, EngineVersion engine, std::string encoding = "");
 
 	/**
-	 * Destructor. Closes the opened file.
-	 */
-	~LcfWriter();
-
-	/**
 	 * Writes raw data to the stream (fwrite() wrapper).
 	 *
 	 * @param ptr pointer to buffer.

--- a/src/ldb_reader.cpp
+++ b/src/ldb_reader.cpp
@@ -22,44 +22,44 @@ void LDB_Reader::PrepareSave(rpg::Database& db) {
 	++db.system.save_count;
 }
 
-std::unique_ptr<lcf::rpg::Database> LDB_Reader::Load(const std::string& filename, const std::string& encoding) {
-	std::ifstream stream(filename.c_str(), std::ios::binary);
+std::unique_ptr<lcf::rpg::Database> LDB_Reader::Load(StringView filename, StringView encoding) {
+	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LDB file `%s' for reading : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LDB file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LDB_Reader::Load(stream, encoding);
 }
 
-bool LDB_Reader::Save(const std::string& filename, const lcf::rpg::Database& db, const std::string& encoding, SaveOpt opt) {
-	std::ofstream stream(filename.c_str(), std::ios::binary);
+bool LDB_Reader::Save(StringView filename, const lcf::rpg::Database& db, StringView encoding, SaveOpt opt) {
+	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LDB file `%s' for writing : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LDB file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LDB_Reader::Save(stream, db, encoding, opt);
 }
 
-bool LDB_Reader::SaveXml(const std::string& filename, const lcf::rpg::Database& db) {
-	std::ofstream stream(filename.c_str(), std::ios::binary);
+bool LDB_Reader::SaveXml(StringView filename, const lcf::rpg::Database& db) {
+	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LDB XML file `%s' for writing : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LDB XML file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LDB_Reader::SaveXml(stream, db);
 }
 
-std::unique_ptr<lcf::rpg::Database> LDB_Reader::LoadXml(const std::string& filename) {
-	std::ifstream stream(filename.c_str(), std::ios::binary);
+std::unique_ptr<lcf::rpg::Database> LDB_Reader::LoadXml(StringView filename) {
+	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LDB XML file `%s' for reading : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LDB XML file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LDB_Reader::LoadXml(stream);
 }
 
-std::unique_ptr<lcf::rpg::Database> LDB_Reader::Load(std::istream& filestream, const std::string& encoding) {
-	LcfReader reader(filestream, encoding);
+std::unique_ptr<lcf::rpg::Database> LDB_Reader::Load(std::istream& filestream, StringView encoding) {
+	LcfReader reader(filestream, ToString(encoding));
 	if (!reader.IsOk()) {
 		LcfReader::SetError("Couldn't parse database file.\n");
 		return nullptr;
@@ -87,9 +87,9 @@ std::unique_ptr<lcf::rpg::Database> LDB_Reader::Load(std::istream& filestream, c
 	return db;
 }
 
-bool LDB_Reader::Save(std::ostream& filestream, const lcf::rpg::Database& db, const std::string& encoding, SaveOpt opt) {
+bool LDB_Reader::Save(std::ostream& filestream, const lcf::rpg::Database& db, StringView encoding, SaveOpt opt) {
 	const auto engine = GetEngineVersion(db);
-	LcfWriter writer(filestream, engine, encoding);
+	LcfWriter writer(filestream, engine, ToString(encoding));
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse database file.\n");
 		return false;

--- a/src/lmt_reader.cpp
+++ b/src/lmt_reader.cpp
@@ -18,44 +18,44 @@
 
 namespace lcf {
 
-std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::Load(const std::string& filename, const std::string& encoding) {
-	std::ifstream stream(filename.c_str(), std::ios::binary);
+std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::Load(StringView filename, StringView encoding) {
+	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMT file `%s' for reading : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LMT file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LMT_Reader::Load(stream, encoding);
 }
 
-bool LMT_Reader::Save(const std::string& filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine, const std::string& encoding, SaveOpt opt) {
-	std::ofstream stream(filename.c_str(), std::ios::binary);
+bool LMT_Reader::Save(StringView filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine, StringView encoding, SaveOpt opt) {
+	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMT file `%s' for writing : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LMT file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LMT_Reader::Save(stream, tmap, engine, encoding, opt);
 }
 
-bool LMT_Reader::SaveXml(const std::string& filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine) {
-	std::ofstream stream(filename.c_str(), std::ios::binary);
+bool LMT_Reader::SaveXml(StringView filename, const lcf::rpg::TreeMap& tmap, EngineVersion engine) {
+	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMT XML file `%s' for writing : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LMT XML file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LMT_Reader::SaveXml(stream, tmap, engine);
 }
 
-std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::LoadXml(const std::string& filename) {
-	std::ifstream stream(filename.c_str(), std::ios::binary);
+std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::LoadXml(StringView filename) {
+	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMT XML file `%s' for reading : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LMT XML file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LMT_Reader::LoadXml(stream);
 }
 
-std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::Load(std::istream& filestream, const std::string &encoding) {
-	LcfReader reader(filestream, encoding);
+std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::Load(std::istream& filestream, StringView encoding) {
+	LcfReader reader(filestream, ToString(encoding));
 	if (!reader.IsOk()) {
 		LcfReader::SetError("Couldn't parse map tree file.\n");
 		return nullptr;
@@ -75,8 +75,8 @@ std::unique_ptr<lcf::rpg::TreeMap> LMT_Reader::Load(std::istream& filestream, co
 	return tmap;
 }
 
-bool LMT_Reader::Save(std::ostream& filestream, const lcf::rpg::TreeMap& tmap, EngineVersion engine, const std::string &encoding, SaveOpt opt) {
-	LcfWriter writer(filestream, engine, encoding);
+bool LMT_Reader::Save(std::ostream& filestream, const lcf::rpg::TreeMap& tmap, EngineVersion engine, StringView encoding, SaveOpt opt) {
+	LcfWriter writer(filestream, engine, ToString(encoding));
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse map tree file.\n");
 		return false;

--- a/src/lmu_reader.cpp
+++ b/src/lmu_reader.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <cerrno>
 #include <cstring>
+#include <memory>
 
 #include "lcf/lmu/reader.h"
 #include "lcf/lmu/chunks.h"
@@ -23,44 +24,44 @@ void LMU_Reader::PrepareSave(rpg::Map& map) {
 	++map.save_count;
 }
 
-std::unique_ptr<rpg::Map> LMU_Reader::Load(const std::string& filename, const std::string& encoding) {
-	std::ifstream stream(filename.c_str(), std::ios::binary);
+std::unique_ptr<rpg::Map> LMU_Reader::Load(StringView filename, StringView encoding) {
+	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMU file `%s' for reading : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LMU file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LMU_Reader::Load(stream, encoding);
 }
 
-bool LMU_Reader::Save(const std::string& filename, const rpg::Map& save, EngineVersion engine, const std::string& encoding, SaveOpt opt) {
-	std::ofstream stream(filename.c_str(), std::ios::binary);
+bool LMU_Reader::Save(StringView filename, const rpg::Map& save, EngineVersion engine, StringView encoding, SaveOpt opt) {
+	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMU file `%s' for writing : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LMU file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LMU_Reader::Save(stream, save, engine, encoding, opt);
 }
 
-bool LMU_Reader::SaveXml(const std::string& filename, const rpg::Map& save, EngineVersion engine) {
-	std::ofstream stream(filename.c_str(), std::ios::binary);
+bool LMU_Reader::SaveXml(StringView filename, const rpg::Map& save, EngineVersion engine) {
+	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMU XML file `%s' for writing : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LMU XML file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LMU_Reader::SaveXml(stream, save, engine);
 }
 
-std::unique_ptr<rpg::Map> LMU_Reader::LoadXml(const std::string& filename) {
-	std::ifstream stream(filename.c_str(), std::ios::binary);
+std::unique_ptr<rpg::Map> LMU_Reader::LoadXml(StringView filename) {
+	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LMU XML file `%s' for reading : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LMU XML file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LMU_Reader::LoadXml(stream);
 }
 
-std::unique_ptr<rpg::Map> LMU_Reader::Load(std::istream& filestream, const std::string& encoding) {
-	LcfReader reader(filestream, encoding);
+std::unique_ptr<rpg::Map> LMU_Reader::Load(std::istream& filestream, StringView encoding) {
+	LcfReader reader(filestream, ToString(encoding));
 	if (!reader.IsOk()) {
 		LcfReader::SetError("Couldn't parse map file.\n");
 		return std::unique_ptr<rpg::Map>();
@@ -75,14 +76,14 @@ std::unique_ptr<rpg::Map> LMU_Reader::Load(std::istream& filestream, const std::
 		fprintf(stderr, "Warning: This header is not LcfMapUnit and might not be a valid RPG2000 map.\n");
 	}
 
-	auto map = std::unique_ptr<rpg::Map>(new rpg::Map());
+	auto map = std::make_unique<rpg::Map>();
 	map->lmu_header = std::move(header);
 	Struct<rpg::Map>::ReadLcf(*map, reader);
 	return map;
 }
 
-bool LMU_Reader::Save(std::ostream& filestream, const rpg::Map& map, EngineVersion engine, const std::string& encoding, SaveOpt opt) {
-	LcfWriter writer(filestream, engine, encoding);
+bool LMU_Reader::Save(std::ostream& filestream, const rpg::Map& map, EngineVersion engine, StringView encoding, SaveOpt opt) {
+	LcfWriter writer(filestream, engine, ToString(encoding));
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse map file.\n");
 		return false;
@@ -119,7 +120,7 @@ std::unique_ptr<rpg::Map> LMU_Reader::LoadXml(std::istream& filestream) {
 		return std::unique_ptr<rpg::Map>();
 	}
 
-	auto map = std::unique_ptr<rpg::Map>(new rpg::Map());
+	auto map = std::make_unique<rpg::Map>();
 	reader.SetHandler(new RootXmlHandler<rpg::Map>(*map, "LMU"));
 	reader.Parse();
 	return map;

--- a/src/lsd_reader.cpp
+++ b/src/lsd_reader.cpp
@@ -20,16 +20,16 @@
 
 namespace lcf {
 
-double LSD_Reader::ToTDateTime(std::time_t const t) {
+double LSD_Reader::ToTDateTime(std::time_t t) {
 	// 25569 is UnixDateDelta: number of days between 1970-01-01 and 1900-01-01
 	return(t / 86400.0 + 25569.0);
 }
 
-std::time_t LSD_Reader::ToUnixTimestamp(double const ms) {
+std::time_t LSD_Reader::ToUnixTimestamp(double ms) {
 	return(std::time_t(ms * 86400.0 - 25569.0 * 86400.0 + 0.5));
 }
 
-double LSD_Reader::GenerateTimestamp(std::time_t const t) {
+double LSD_Reader::GenerateTimestamp(std::time_t t) {
 	return ToTDateTime(t);
 }
 
@@ -39,44 +39,44 @@ void LSD_Reader::PrepareSave(rpg::Save& save, int32_t version) {
 	save.easyrpg_data.version = version;
 }
 
-std::unique_ptr<rpg::Save> LSD_Reader::Load(const std::string& filename, const std::string& encoding) {
-	std::ifstream stream(filename.c_str(), std::ios::binary);
+std::unique_ptr<rpg::Save> LSD_Reader::Load(StringView filename, StringView encoding) {
+	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LSD file `%s' for reading : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LSD file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LSD_Reader::Load(stream, encoding);
 }
 
-bool LSD_Reader::Save(const std::string& filename, const rpg::Save& save, EngineVersion engine, const std::string& encoding) {
-	std::ofstream stream(filename.c_str(), std::ios::binary);
+bool LSD_Reader::Save(StringView filename, const rpg::Save& save, EngineVersion engine, StringView encoding) {
+	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LSD file `%s' for writing : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LSD file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LSD_Reader::Save(stream, save, engine, encoding);
 }
 
-bool LSD_Reader::SaveXml(const std::string& filename, const rpg::Save& save, EngineVersion engine) {
-	std::ofstream stream(filename.c_str(), std::ios::binary);
+bool LSD_Reader::SaveXml(StringView filename, const rpg::Save& save, EngineVersion engine) {
+	std::ofstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LSD XML file `%s' for writing : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LSD XML file `%s' for writing : %s\n", ToString(filename).c_str(), strerror(errno));
 		return false;
 	}
 	return LSD_Reader::SaveXml(stream, save, engine);
 }
 
-std::unique_ptr<rpg::Save> LSD_Reader::LoadXml(const std::string& filename) {
-	std::ifstream stream(filename.c_str(), std::ios::binary);
+std::unique_ptr<rpg::Save> LSD_Reader::LoadXml(StringView filename) {
+	std::ifstream stream(ToString(filename), std::ios::binary);
 	if (!stream.is_open()) {
-		fprintf(stderr, "Failed to open LSD XML file `%s' for reading : %s\n", filename.c_str(), strerror(errno));
+		fprintf(stderr, "Failed to open LSD XML file `%s' for reading : %s\n", ToString(filename).c_str(), strerror(errno));
 		return nullptr;
 	}
 	return LSD_Reader::LoadXml(stream);
 }
 
-std::unique_ptr<rpg::Save> LSD_Reader::Load(std::istream& filestream, const std::string &encoding) {
-	LcfReader reader(filestream, encoding);
+std::unique_ptr<rpg::Save> LSD_Reader::Load(std::istream& filestream, StringView encoding) {
+	LcfReader reader(filestream, ToString(encoding));
 	if (!reader.IsOk()) {
 		LcfReader::SetError("Couldn't parse save file.\n");
 		return std::unique_ptr<rpg::Save>();
@@ -95,8 +95,8 @@ std::unique_ptr<rpg::Save> LSD_Reader::Load(std::istream& filestream, const std:
 	return std::unique_ptr<rpg::Save>(save);
 }
 
-bool LSD_Reader::Save(std::ostream& filestream, const rpg::Save& save, EngineVersion engine, const std::string &encoding) {
-	LcfWriter writer(filestream, engine, encoding);
+bool LSD_Reader::Save(std::ostream& filestream, const rpg::Save& save, EngineVersion engine, StringView encoding) {
+	LcfWriter writer(filestream, engine, ToString(encoding));
 	if (!writer.IsOk()) {
 		LcfReader::SetError("Couldn't parse save file.\n");
 		return false;

--- a/src/reader_lcf.cpp
+++ b/src/reader_lcf.cpp
@@ -25,9 +25,6 @@ LcfReader::LcfReader(std::istream& filestream, std::string encoding)
 	offset = filestream.tellg();
 }
 
-LcfReader::~LcfReader() {
-}
-
 size_t LcfReader::Read0(void *ptr, size_t size, size_t nmemb) {
 	if (size == 0) { //avoid division by 0
 		return 0;

--- a/src/writer_lcf.cpp
+++ b/src/writer_lcf.cpp
@@ -20,10 +20,6 @@ LcfWriter::LcfWriter(std::ostream& filestream, EngineVersion engine, std::string
 {
 }
 
-LcfWriter::~LcfWriter() {
-
-}
-
 void LcfWriter::Write(const void *ptr, size_t size, size_t nmemb) {
 	stream.write(reinterpret_cast<const char*>(ptr), size*nmemb);
 	assert(stream.good());


### PR DESCRIPTION
The first commit is not really needed for it but it makes it after 0.7 easier to replace StringView with std::string_view (C++17). This is API compatible, no changes needed to consumers.

The second commit changes the Encoding Api from Streams to a Database-handle. Because we do not operate on global objects anymore the database checked by player was always empty. This fixes it (Player loads the DB and passes it in). I also noticed that for whatever reason the language detection is better when system tab is at the beginning (maybe filenames are better than terms because they are usually unaffected by translations?)



