### PR TITLE
Rename some chunks to make their purpose more clear

### DIFF
--- a/.github/workflows/stable-compilation.yml
+++ b/.github/workflows/stable-compilation.yml
@@ -20,11 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - ubuntu:18.04  # CMake 3.10.2 - g++ 7.4.0  - LTS
-          - debian:10     # CMake 3.13.4 - g++ 8.3.0  - old
+          - debian:10     # CMake 3.13.4 - g++ 8.3.0  - oldstable
           - ubuntu:20.04  # CMake 3.16.3 - g++ 9.3.0  - LTS
-          - ubuntu:21.04  # CMake 3.18.4 - g++ 10.3.0 - stable
-
+          - debian:11     # CMake 3.18.4 - g++ 10.2.1 - stable
+          - ubuntu:22.04  # CMake 3.22.1 - g++ 11.2.0 - LTS
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -42,12 +41,9 @@ jobs:
 
       - name: Compile
         run: |
-          mkdir build
-          cd build
-          # cmake < 3.13 does not support '-B'
-          cmake -G Ninja .. \
+          cmake -G Ninja -B build . \
             -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
-          cmake --build .
+          cmake --build build
 
       - name: Install
         run: |

--- a/generator/csv/enums.csv
+++ b/generator/csv/enums.csv
@@ -407,7 +407,7 @@ EventCommand,Code,ShowPicture,11110
 EventCommand,Code,MovePicture,11120
 EventCommand,Code,ErasePicture,11130
 EventCommand,Code,ShowBattleAnimation,11210
-EventCommand,Code,SpriteTransparency,11310
+EventCommand,Code,PlayerVisibility,11310
 EventCommand,Code,FlashSprite,11320
 EventCommand,Code,MoveEvent,11330
 EventCommand,Code,ProceedWithMovement,11340

--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -943,8 +943,8 @@ SaveMapEventBase,active,f,Boolean,0x01,True,0,0,Flag
 SaveMapEventBase,map_id,f,Int32,0x0B,0,1,0,?
 SaveMapEventBase,position_x,f,Int32,0x0C,0,1,0,?
 SaveMapEventBase,position_y,f,Int32,0x0D,0,1,0,?
-SaveMapEventBase,direction,f,Int32,0x15,2,1,0,Facing direction
-SaveMapEventBase,sprite_direction,f,Int32,0x16,2,1,0,Sprite direction
+SaveMapEventBase,direction,f,Int32,0x15,2,1,0,Sprite direction
+SaveMapEventBase,facing,f,Int32,0x16,2,1,0,Facing direction
 SaveMapEventBase,anim_frame,f,Int32,0x17,1,0,0,?
 SaveMapEventBase,transparency,f,Int32,0x18,0,0,0,0 or 3 - Transparency level of the current event page
 SaveMapEventBase,remaining_step,f,Int32,0x1F,0,0,0,From 0 to 255 - Remaining distance of the current move
@@ -957,9 +957,9 @@ SaveMapEventBase,move_speed,f,Int32,0x25,4,1,0,
 SaveMapEventBase,move_route,f,MoveRoute,0x29,,1,0,chunks: rpg::MoveRoute
 SaveMapEventBase,move_route_overwrite,f,Boolean,0x2A,False,0,0,Use custom move route
 SaveMapEventBase,move_route_index,f,Int32,0x2B,0,0,0,Index of MoveEvent command route
-SaveMapEventBase,move_route_repeated,f,Boolean,0x2C,False,0,0,Boolean - Repeating move route has been completed at least once
-SaveMapEventBase,sprite_transparent,f,Boolean,0x2E,False,0,0,bool
-SaveMapEventBase,route_through,f,Boolean,0x2F,False,0,0,Whether the move route (MoveEvent or defined route) activated through mode. Almost the same as 0x33 (through). 0x2F represents that by MoveEvent the through mode has been activated; but 0x33 is what's actually checked for collisions. In several cases; 0x33 will be changed to indicate a condition in which an event or the hero is in through mode through other means than a MoveEvent; which can be: an event with an empty page being activated; player pressing Ctrl in test play; hero entering or exiting a vehicle (only very briefly)
+SaveMapEventBase,move_route_finished,f,Boolean,0x2C,False,0,0,Boolean - Repeating move route has been completed at least once
+SaveMapEventBase,sprite_hidden,f,Boolean,0x2E,False,0,0,When true the sprite is not displayed
+SaveMapEventBase,move_route_through,f,Boolean,0x2F,False,0,0,Whether the move route (MoveEvent or defined route) activated through mode. Almost the same as 0x33 (through). 0x2F represents that by MoveEvent the through mode has been activated; but 0x33 is what's actually checked for collisions. In several cases; 0x33 will be changed to indicate a condition in which an event or the hero is in through mode through other means than a MoveEvent; which can be: an event with an empty page being activated; player pressing Ctrl in test play; hero entering or exiting a vehicle (only very briefly)
 SaveMapEventBase,anim_paused,f,Int32,0x30,0,0,0,?
 SaveMapEventBase,through,f,Boolean,0x33,False,0,0,Can go through anything
 SaveMapEventBase,stop_count,f,Int32,0x34,0,0,0,?

--- a/src/generated/lcf/lsd/chunks.h
+++ b/src/generated/lcf/lsd/chunks.h
@@ -330,10 +330,10 @@ namespace LSD_Reader {
 			position_x = 0x0C,
 			/** ? */
 			position_y = 0x0D,
-			/** Facing direction */
-			direction = 0x15,
 			/** Sprite direction */
-			sprite_direction = 0x16,
+			direction = 0x15,
+			/** Facing direction */
+			facing = 0x16,
 			/** ? */
 			anim_frame = 0x17,
 			/** 0 or 3 - Transparency level of the current event page */
@@ -359,11 +359,11 @@ namespace LSD_Reader {
 			/** Index of MoveEvent command route */
 			move_route_index = 0x2B,
 			/** Boolean - Repeating move route has been completed at least once */
-			move_route_repeated = 0x2C,
-			/** bool */
-			sprite_transparent = 0x2E,
+			move_route_finished = 0x2C,
+			/** When true the sprite is not displayed */
+			sprite_hidden = 0x2E,
 			/** Whether the move route (MoveEvent or defined route) activated through mode. Almost the same as 0x33 (through). 0x2F represents that by MoveEvent the through mode has been activated; but 0x33 is what's actually checked for collisions. In several cases; 0x33 will be changed to indicate a condition in which an event or the hero is in through mode through other means than a MoveEvent; which can be: an event with an empty page being activated; player pressing Ctrl in test play; hero entering or exiting a vehicle (only very briefly) */
-			route_through = 0x2F,
+			move_route_through = 0x2F,
 			/** ? */
 			anim_paused = 0x30,
 			/** Can go through anything */
@@ -444,10 +444,10 @@ namespace LSD_Reader {
 			position_x = 0x0C,
 			/** ? */
 			position_y = 0x0D,
-			/** Facing direction */
-			direction = 0x15,
 			/** Sprite direction */
-			sprite_direction = 0x16,
+			direction = 0x15,
+			/** Facing direction */
+			facing = 0x16,
 			/** ? */
 			anim_frame = 0x17,
 			/** 0 or 3 - Transparency level of the current event page */
@@ -473,11 +473,11 @@ namespace LSD_Reader {
 			/** Index of MoveEvent command route */
 			move_route_index = 0x2B,
 			/** Boolean - Repeating move route has been completed at least once */
-			move_route_repeated = 0x2C,
-			/** bool */
-			sprite_transparent = 0x2E,
+			move_route_finished = 0x2C,
+			/** When true the sprite is not displayed */
+			sprite_hidden = 0x2E,
 			/** Whether the move route (MoveEvent or defined route) activated through mode. Almost the same as 0x33 (through). 0x2F represents that by MoveEvent the through mode has been activated; but 0x33 is what's actually checked for collisions. In several cases; 0x33 will be changed to indicate a condition in which an event or the hero is in through mode through other means than a MoveEvent; which can be: an event with an empty page being activated; player pressing Ctrl in test play; hero entering or exiting a vehicle (only very briefly) */
-			route_through = 0x2F,
+			move_route_through = 0x2F,
 			/** ? */
 			anim_paused = 0x30,
 			/** Can go through anything */
@@ -738,10 +738,10 @@ namespace LSD_Reader {
 			position_x = 0x0C,
 			/** ? */
 			position_y = 0x0D,
-			/** Facing direction */
-			direction = 0x15,
 			/** Sprite direction */
-			sprite_direction = 0x16,
+			direction = 0x15,
+			/** Facing direction */
+			facing = 0x16,
 			/** ? */
 			anim_frame = 0x17,
 			/** 0 or 3 - Transparency level of the current event page */
@@ -767,11 +767,11 @@ namespace LSD_Reader {
 			/** Index of MoveEvent command route */
 			move_route_index = 0x2B,
 			/** Boolean - Repeating move route has been completed at least once */
-			move_route_repeated = 0x2C,
-			/** bool */
-			sprite_transparent = 0x2E,
+			move_route_finished = 0x2C,
+			/** When true the sprite is not displayed */
+			sprite_hidden = 0x2E,
 			/** Whether the move route (MoveEvent or defined route) activated through mode. Almost the same as 0x33 (through). 0x2F represents that by MoveEvent the through mode has been activated; but 0x33 is what's actually checked for collisions. In several cases; 0x33 will be changed to indicate a condition in which an event or the hero is in through mode through other means than a MoveEvent; which can be: an event with an empty page being activated; player pressing Ctrl in test play; hero entering or exiting a vehicle (only very briefly) */
-			route_through = 0x2F,
+			move_route_through = 0x2F,
 			/** ? */
 			anim_paused = 0x30,
 			/** Can go through anything */
@@ -820,10 +820,10 @@ namespace LSD_Reader {
 			position_x = 0x0C,
 			/** ? */
 			position_y = 0x0D,
-			/** Facing direction */
-			direction = 0x15,
 			/** Sprite direction */
-			sprite_direction = 0x16,
+			direction = 0x15,
+			/** Facing direction */
+			facing = 0x16,
 			/** ? */
 			anim_frame = 0x17,
 			/** 0 or 3 - Transparency level of the current event page */
@@ -849,11 +849,11 @@ namespace LSD_Reader {
 			/** Index of MoveEvent command route */
 			move_route_index = 0x2B,
 			/** Boolean - Repeating move route has been completed at least once */
-			move_route_repeated = 0x2C,
-			/** bool */
-			sprite_transparent = 0x2E,
+			move_route_finished = 0x2C,
+			/** When true the sprite is not displayed */
+			sprite_hidden = 0x2E,
 			/** Whether the move route (MoveEvent or defined route) activated through mode. Almost the same as 0x33 (through). 0x2F represents that by MoveEvent the through mode has been activated; but 0x33 is what's actually checked for collisions. In several cases; 0x33 will be changed to indicate a condition in which an event or the hero is in through mode through other means than a MoveEvent; which can be: an event with an empty page being activated; player pressing Ctrl in test play; hero entering or exiting a vehicle (only very briefly) */
-			route_through = 0x2F,
+			move_route_through = 0x2F,
 			/** ? */
 			anim_paused = 0x30,
 			/** Can go through anything */

--- a/src/generated/lcf/rpg/eventcommand.h
+++ b/src/generated/lcf/rpg/eventcommand.h
@@ -94,7 +94,7 @@ namespace rpg {
 			MovePicture = 11120,
 			ErasePicture = 11130,
 			ShowBattleAnimation = 11210,
-			SpriteTransparency = 11310,
+			PlayerVisibility = 11310,
 			FlashSprite = 11320,
 			MoveEvent = 11330,
 			ProceedWithMovement = 11340,

--- a/src/generated/lcf/rpg/savemapeventbase.h
+++ b/src/generated/lcf/rpg/savemapeventbase.h
@@ -33,7 +33,7 @@ namespace rpg {
 		int32_t position_x = 0;
 		int32_t position_y = 0;
 		int32_t direction = 2;
-		int32_t sprite_direction = 2;
+		int32_t facing = 2;
 		int32_t anim_frame = 1;
 		int32_t transparency = 0;
 		int32_t remaining_step = 0;
@@ -46,9 +46,9 @@ namespace rpg {
 		MoveRoute move_route;
 		bool move_route_overwrite = false;
 		int32_t move_route_index = 0;
-		bool move_route_repeated = false;
-		bool sprite_transparent = false;
-		bool route_through = false;
+		bool move_route_finished = false;
+		bool sprite_hidden = false;
+		bool move_route_through = false;
 		int32_t anim_paused = 0;
 		bool through = false;
 		int32_t stop_count = 0;
@@ -75,7 +75,7 @@ namespace rpg {
 		&& l.position_x == r.position_x
 		&& l.position_y == r.position_y
 		&& l.direction == r.direction
-		&& l.sprite_direction == r.sprite_direction
+		&& l.facing == r.facing
 		&& l.anim_frame == r.anim_frame
 		&& l.transparency == r.transparency
 		&& l.remaining_step == r.remaining_step
@@ -88,9 +88,9 @@ namespace rpg {
 		&& l.move_route == r.move_route
 		&& l.move_route_overwrite == r.move_route_overwrite
 		&& l.move_route_index == r.move_route_index
-		&& l.move_route_repeated == r.move_route_repeated
-		&& l.sprite_transparent == r.sprite_transparent
-		&& l.route_through == r.route_through
+		&& l.move_route_finished == r.move_route_finished
+		&& l.sprite_hidden == r.sprite_hidden
+		&& l.move_route_through == r.move_route_through
 		&& l.anim_paused == r.anim_paused
 		&& l.through == r.through
 		&& l.stop_count == r.stop_count

--- a/src/generated/lsd_savemapevent.cpp
+++ b/src/generated/lsd_savemapevent.cpp
@@ -55,10 +55,10 @@ static TypedField<rpg::SaveMapEvent, int32_t> static_direction(
 	1,
 	0
 );
-static TypedField<rpg::SaveMapEvent, int32_t> static_sprite_direction(
-	&rpg::SaveMapEvent::sprite_direction,
-	LSD_Reader::ChunkSaveMapEvent::sprite_direction,
-	"sprite_direction",
+static TypedField<rpg::SaveMapEvent, int32_t> static_facing(
+	&rpg::SaveMapEvent::facing,
+	LSD_Reader::ChunkSaveMapEvent::facing,
+	"facing",
 	1,
 	0
 );
@@ -146,24 +146,24 @@ static TypedField<rpg::SaveMapEvent, int32_t> static_move_route_index(
 	0,
 	0
 );
-static TypedField<rpg::SaveMapEvent, bool> static_move_route_repeated(
-	&rpg::SaveMapEvent::move_route_repeated,
-	LSD_Reader::ChunkSaveMapEvent::move_route_repeated,
-	"move_route_repeated",
+static TypedField<rpg::SaveMapEvent, bool> static_move_route_finished(
+	&rpg::SaveMapEvent::move_route_finished,
+	LSD_Reader::ChunkSaveMapEvent::move_route_finished,
+	"move_route_finished",
 	0,
 	0
 );
-static TypedField<rpg::SaveMapEvent, bool> static_sprite_transparent(
-	&rpg::SaveMapEvent::sprite_transparent,
-	LSD_Reader::ChunkSaveMapEvent::sprite_transparent,
-	"sprite_transparent",
+static TypedField<rpg::SaveMapEvent, bool> static_sprite_hidden(
+	&rpg::SaveMapEvent::sprite_hidden,
+	LSD_Reader::ChunkSaveMapEvent::sprite_hidden,
+	"sprite_hidden",
 	0,
 	0
 );
-static TypedField<rpg::SaveMapEvent, bool> static_route_through(
-	&rpg::SaveMapEvent::route_through,
-	LSD_Reader::ChunkSaveMapEvent::route_through,
-	"route_through",
+static TypedField<rpg::SaveMapEvent, bool> static_move_route_through(
+	&rpg::SaveMapEvent::move_route_through,
+	LSD_Reader::ChunkSaveMapEvent::move_route_through,
+	"move_route_through",
 	0,
 	0
 );
@@ -330,7 +330,7 @@ Field<rpg::SaveMapEvent> const* Struct<rpg::SaveMapEvent>::fields[] = {
 	&static_position_x,
 	&static_position_y,
 	&static_direction,
-	&static_sprite_direction,
+	&static_facing,
 	&static_anim_frame,
 	&static_transparency,
 	&static_remaining_step,
@@ -343,9 +343,9 @@ Field<rpg::SaveMapEvent> const* Struct<rpg::SaveMapEvent>::fields[] = {
 	&static_move_route,
 	&static_move_route_overwrite,
 	&static_move_route_index,
-	&static_move_route_repeated,
-	&static_sprite_transparent,
-	&static_route_through,
+	&static_move_route_finished,
+	&static_sprite_hidden,
+	&static_move_route_through,
 	&static_anim_paused,
 	&static_through,
 	&static_stop_count,

--- a/src/generated/lsd_savemapeventbase.cpp
+++ b/src/generated/lsd_savemapeventbase.cpp
@@ -55,10 +55,10 @@ static TypedField<rpg::SaveMapEventBase, int32_t> static_direction(
 	1,
 	0
 );
-static TypedField<rpg::SaveMapEventBase, int32_t> static_sprite_direction(
-	&rpg::SaveMapEventBase::sprite_direction,
-	LSD_Reader::ChunkSaveMapEventBase::sprite_direction,
-	"sprite_direction",
+static TypedField<rpg::SaveMapEventBase, int32_t> static_facing(
+	&rpg::SaveMapEventBase::facing,
+	LSD_Reader::ChunkSaveMapEventBase::facing,
+	"facing",
 	1,
 	0
 );
@@ -146,24 +146,24 @@ static TypedField<rpg::SaveMapEventBase, int32_t> static_move_route_index(
 	0,
 	0
 );
-static TypedField<rpg::SaveMapEventBase, bool> static_move_route_repeated(
-	&rpg::SaveMapEventBase::move_route_repeated,
-	LSD_Reader::ChunkSaveMapEventBase::move_route_repeated,
-	"move_route_repeated",
+static TypedField<rpg::SaveMapEventBase, bool> static_move_route_finished(
+	&rpg::SaveMapEventBase::move_route_finished,
+	LSD_Reader::ChunkSaveMapEventBase::move_route_finished,
+	"move_route_finished",
 	0,
 	0
 );
-static TypedField<rpg::SaveMapEventBase, bool> static_sprite_transparent(
-	&rpg::SaveMapEventBase::sprite_transparent,
-	LSD_Reader::ChunkSaveMapEventBase::sprite_transparent,
-	"sprite_transparent",
+static TypedField<rpg::SaveMapEventBase, bool> static_sprite_hidden(
+	&rpg::SaveMapEventBase::sprite_hidden,
+	LSD_Reader::ChunkSaveMapEventBase::sprite_hidden,
+	"sprite_hidden",
 	0,
 	0
 );
-static TypedField<rpg::SaveMapEventBase, bool> static_route_through(
-	&rpg::SaveMapEventBase::route_through,
-	LSD_Reader::ChunkSaveMapEventBase::route_through,
-	"route_through",
+static TypedField<rpg::SaveMapEventBase, bool> static_move_route_through(
+	&rpg::SaveMapEventBase::move_route_through,
+	LSD_Reader::ChunkSaveMapEventBase::move_route_through,
+	"move_route_through",
 	0,
 	0
 );
@@ -302,7 +302,7 @@ Field<rpg::SaveMapEventBase> const* Struct<rpg::SaveMapEventBase>::fields[] = {
 	&static_position_x,
 	&static_position_y,
 	&static_direction,
-	&static_sprite_direction,
+	&static_facing,
 	&static_anim_frame,
 	&static_transparency,
 	&static_remaining_step,
@@ -315,9 +315,9 @@ Field<rpg::SaveMapEventBase> const* Struct<rpg::SaveMapEventBase>::fields[] = {
 	&static_move_route,
 	&static_move_route_overwrite,
 	&static_move_route_index,
-	&static_move_route_repeated,
-	&static_sprite_transparent,
-	&static_route_through,
+	&static_move_route_finished,
+	&static_sprite_hidden,
+	&static_move_route_through,
 	&static_anim_paused,
 	&static_through,
 	&static_stop_count,

--- a/src/generated/lsd_savepartylocation.cpp
+++ b/src/generated/lsd_savepartylocation.cpp
@@ -55,10 +55,10 @@ static TypedField<rpg::SavePartyLocation, int32_t> static_direction(
 	1,
 	0
 );
-static TypedField<rpg::SavePartyLocation, int32_t> static_sprite_direction(
-	&rpg::SavePartyLocation::sprite_direction,
-	LSD_Reader::ChunkSavePartyLocation::sprite_direction,
-	"sprite_direction",
+static TypedField<rpg::SavePartyLocation, int32_t> static_facing(
+	&rpg::SavePartyLocation::facing,
+	LSD_Reader::ChunkSavePartyLocation::facing,
+	"facing",
 	1,
 	0
 );
@@ -146,24 +146,24 @@ static TypedField<rpg::SavePartyLocation, int32_t> static_move_route_index(
 	0,
 	0
 );
-static TypedField<rpg::SavePartyLocation, bool> static_move_route_repeated(
-	&rpg::SavePartyLocation::move_route_repeated,
-	LSD_Reader::ChunkSavePartyLocation::move_route_repeated,
-	"move_route_repeated",
+static TypedField<rpg::SavePartyLocation, bool> static_move_route_finished(
+	&rpg::SavePartyLocation::move_route_finished,
+	LSD_Reader::ChunkSavePartyLocation::move_route_finished,
+	"move_route_finished",
 	0,
 	0
 );
-static TypedField<rpg::SavePartyLocation, bool> static_sprite_transparent(
-	&rpg::SavePartyLocation::sprite_transparent,
-	LSD_Reader::ChunkSavePartyLocation::sprite_transparent,
-	"sprite_transparent",
+static TypedField<rpg::SavePartyLocation, bool> static_sprite_hidden(
+	&rpg::SavePartyLocation::sprite_hidden,
+	LSD_Reader::ChunkSavePartyLocation::sprite_hidden,
+	"sprite_hidden",
 	0,
 	0
 );
-static TypedField<rpg::SavePartyLocation, bool> static_route_through(
-	&rpg::SavePartyLocation::route_through,
-	LSD_Reader::ChunkSavePartyLocation::route_through,
-	"route_through",
+static TypedField<rpg::SavePartyLocation, bool> static_move_route_through(
+	&rpg::SavePartyLocation::move_route_through,
+	LSD_Reader::ChunkSavePartyLocation::move_route_through,
+	"move_route_through",
 	0,
 	0
 );
@@ -414,7 +414,7 @@ Field<rpg::SavePartyLocation> const* Struct<rpg::SavePartyLocation>::fields[] = 
 	&static_position_x,
 	&static_position_y,
 	&static_direction,
-	&static_sprite_direction,
+	&static_facing,
 	&static_anim_frame,
 	&static_transparency,
 	&static_remaining_step,
@@ -427,9 +427,9 @@ Field<rpg::SavePartyLocation> const* Struct<rpg::SavePartyLocation>::fields[] = 
 	&static_move_route,
 	&static_move_route_overwrite,
 	&static_move_route_index,
-	&static_move_route_repeated,
-	&static_sprite_transparent,
-	&static_route_through,
+	&static_move_route_finished,
+	&static_sprite_hidden,
+	&static_move_route_through,
 	&static_anim_paused,
 	&static_through,
 	&static_stop_count,

--- a/src/generated/lsd_savevehiclelocation.cpp
+++ b/src/generated/lsd_savevehiclelocation.cpp
@@ -55,10 +55,10 @@ static TypedField<rpg::SaveVehicleLocation, int32_t> static_direction(
 	1,
 	0
 );
-static TypedField<rpg::SaveVehicleLocation, int32_t> static_sprite_direction(
-	&rpg::SaveVehicleLocation::sprite_direction,
-	LSD_Reader::ChunkSaveVehicleLocation::sprite_direction,
-	"sprite_direction",
+static TypedField<rpg::SaveVehicleLocation, int32_t> static_facing(
+	&rpg::SaveVehicleLocation::facing,
+	LSD_Reader::ChunkSaveVehicleLocation::facing,
+	"facing",
 	1,
 	0
 );
@@ -146,24 +146,24 @@ static TypedField<rpg::SaveVehicleLocation, int32_t> static_move_route_index(
 	0,
 	0
 );
-static TypedField<rpg::SaveVehicleLocation, bool> static_move_route_repeated(
-	&rpg::SaveVehicleLocation::move_route_repeated,
-	LSD_Reader::ChunkSaveVehicleLocation::move_route_repeated,
-	"move_route_repeated",
+static TypedField<rpg::SaveVehicleLocation, bool> static_move_route_finished(
+	&rpg::SaveVehicleLocation::move_route_finished,
+	LSD_Reader::ChunkSaveVehicleLocation::move_route_finished,
+	"move_route_finished",
 	0,
 	0
 );
-static TypedField<rpg::SaveVehicleLocation, bool> static_sprite_transparent(
-	&rpg::SaveVehicleLocation::sprite_transparent,
-	LSD_Reader::ChunkSaveVehicleLocation::sprite_transparent,
-	"sprite_transparent",
+static TypedField<rpg::SaveVehicleLocation, bool> static_sprite_hidden(
+	&rpg::SaveVehicleLocation::sprite_hidden,
+	LSD_Reader::ChunkSaveVehicleLocation::sprite_hidden,
+	"sprite_hidden",
 	0,
 	0
 );
-static TypedField<rpg::SaveVehicleLocation, bool> static_route_through(
-	&rpg::SaveVehicleLocation::route_through,
-	LSD_Reader::ChunkSaveVehicleLocation::route_through,
-	"route_through",
+static TypedField<rpg::SaveVehicleLocation, bool> static_move_route_through(
+	&rpg::SaveVehicleLocation::move_route_through,
+	LSD_Reader::ChunkSaveVehicleLocation::move_route_through,
+	"move_route_through",
 	0,
 	0
 );
@@ -337,7 +337,7 @@ Field<rpg::SaveVehicleLocation> const* Struct<rpg::SaveVehicleLocation>::fields[
 	&static_position_x,
 	&static_position_y,
 	&static_direction,
-	&static_sprite_direction,
+	&static_facing,
 	&static_anim_frame,
 	&static_transparency,
 	&static_remaining_step,
@@ -350,9 +350,9 @@ Field<rpg::SaveVehicleLocation> const* Struct<rpg::SaveVehicleLocation>::fields[
 	&static_move_route,
 	&static_move_route_overwrite,
 	&static_move_route_index,
-	&static_move_route_repeated,
-	&static_sprite_transparent,
-	&static_route_through,
+	&static_move_route_finished,
+	&static_sprite_hidden,
+	&static_move_route_through,
 	&static_anim_paused,
 	&static_through,
 	&static_stop_count,

--- a/src/generated/rpg_savemapeventbase.cpp
+++ b/src/generated/rpg_savemapeventbase.cpp
@@ -22,7 +22,7 @@ std::ostream& operator<<(std::ostream& os, const SaveMapEventBase& obj) {
 	os << ", position_x="<< obj.position_x;
 	os << ", position_y="<< obj.position_y;
 	os << ", direction="<< obj.direction;
-	os << ", sprite_direction="<< obj.sprite_direction;
+	os << ", facing="<< obj.facing;
 	os << ", anim_frame="<< obj.anim_frame;
 	os << ", transparency="<< obj.transparency;
 	os << ", remaining_step="<< obj.remaining_step;
@@ -35,9 +35,9 @@ std::ostream& operator<<(std::ostream& os, const SaveMapEventBase& obj) {
 	os << ", move_route="<< obj.move_route;
 	os << ", move_route_overwrite="<< obj.move_route_overwrite;
 	os << ", move_route_index="<< obj.move_route_index;
-	os << ", move_route_repeated="<< obj.move_route_repeated;
-	os << ", sprite_transparent="<< obj.sprite_transparent;
-	os << ", route_through="<< obj.route_through;
+	os << ", move_route_finished="<< obj.move_route_finished;
+	os << ", sprite_hidden="<< obj.sprite_hidden;
+	os << ", move_route_through="<< obj.move_route_through;
 	os << ", anim_paused="<< obj.anim_paused;
 	os << ", through="<< obj.through;
 	os << ", stop_count="<< obj.stop_count;


### PR DESCRIPTION
(Player PR follows soon)


move_route_repeated -> move_route_done
sprite_direction -> facing
sprite_transparent -> sprite_hidden
route_through -> move_route_through

Event command SpriteTransparency -> PlayerVisibility This cmd only toggles visible and hidden, not transparency

Fix #378