### PR TITLE
Add custom chunks required for ShowStringPicture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,10 @@ set(LCF_SOURCES
 	src/generated/lsd_saveactor.cpp
 	src/generated/lsd_savecommonevent.cpp
 	src/generated/lsd_saveeasyrpgdata.cpp
+	src/generated/lsd_saveeasyrpgtext.cpp
+	src/generated/lsd_saveeasyrpgtext_flags.h
+	src/generated/lsd_saveeasyrpgwindow.cpp
+	src/generated/lsd_saveeasyrpgwindow_flags.h
 	src/generated/lsd_saveeventexecframe.cpp
 	src/generated/lsd_saveeventexecstate.cpp
 	src/generated/lsd_saveinventory.cpp
@@ -155,6 +159,8 @@ set(LCF_SOURCES
 	src/generated/rpg_saveactor.cpp
 	src/generated/rpg_savecommonevent.cpp
 	src/generated/rpg_saveeasyrpgdata.cpp
+	src/generated/rpg_saveeasyrpgtext.cpp
+	src/generated/rpg_saveeasyrpgwindow.cpp
 	src/generated/rpg_saveeventexecframe.cpp
 	src/generated/rpg_saveeventexecstate.cpp
 	src/generated/rpg_saveinventory.cpp
@@ -252,6 +258,8 @@ set(LCF_HEADERS
 	src/generated/lcf/rpg/saveactor.h
 	src/generated/lcf/rpg/savecommonevent.h
 	src/generated/lcf/rpg/saveeasyrpgdata.h
+	src/generated/lcf/rpg/saveeasyrpgtext.h
+	src/generated/lcf/rpg/saveeasyrpgwindow.h
 	src/generated/lcf/rpg/saveeventexecframe.h
 	src/generated/lcf/rpg/saveeventexecstate.h
 	src/generated/lcf/rpg/saveinventory.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -114,6 +114,10 @@ liblcf_la_SOURCES = \
 	src/generated/lsd_saveactor.cpp \
 	src/generated/lsd_savecommonevent.cpp \
 	src/generated/lsd_saveeasyrpgdata.cpp \
+	src/generated/lsd_saveeasyrpgtext.cpp \
+	src/generated/lsd_saveeasyrpgtext_flags.h \
+	src/generated/lsd_saveeasyrpgwindow.cpp \
+	src/generated/lsd_saveeasyrpgwindow_flags.h \
 	src/generated/lsd_saveeventexecframe.cpp \
 	src/generated/lsd_saveeventexecstate.cpp \
 	src/generated/lsd_saveinventory.cpp \
@@ -167,6 +171,8 @@ liblcf_la_SOURCES = \
 	src/generated/rpg_saveactor.cpp \
 	src/generated/rpg_savecommonevent.cpp \
 	src/generated/rpg_saveeasyrpgdata.cpp \
+	src/generated/rpg_saveeasyrpgtext.cpp \
+	src/generated/rpg_saveeasyrpgwindow.cpp \
 	src/generated/rpg_saveeventexecframe.cpp \
 	src/generated/rpg_saveeventexecstate.cpp \
 	src/generated/rpg_saveinventory.cpp \
@@ -273,6 +279,8 @@ lcfrpginclude_HEADERS = \
 	src/generated/lcf/rpg/saveactor.h \
 	src/generated/lcf/rpg/savecommonevent.h \
 	src/generated/lcf/rpg/saveeasyrpgdata.h \
+	src/generated/lcf/rpg/saveeasyrpgtext.h \
+	src/generated/lcf/rpg/saveeasyrpgwindow.h \
 	src/generated/lcf/rpg/saveeventexecframe.h \
 	src/generated/lcf/rpg/saveeventexecstate.h \
 	src/generated/lcf/rpg/saveinventory.h \

--- a/generator/csv/enums.csv
+++ b/generator/csv/enums.csv
@@ -224,6 +224,7 @@ System,FadeIn,instantaneous,20
 System,FadeIn,none,21
 System,Stretch,stretch,0
 System,Stretch,tiled,1
+System,Stretch,easyrpg_none,2
 System,Font,gothic,0
 System,Font,mincho,1
 System,BattleFormation,terrain,0

--- a/generator/csv/enums_easyrpg.csv
+++ b/generator/csv/enums_easyrpg.csv
@@ -33,5 +33,7 @@ SavePicture,EasyRpgFlip,none,0
 SavePicture,EasyRpgFlip,x,1
 SavePicture,EasyRpgFlip,y,2
 SavePicture,EasyRpgFlip,both,3
+SavePicture,EasyRpgType,default,0
+SavePicture,EasyRpgType,window,1
 Skill,HpType,cost,0
 Skill,HpType,percent,1

--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -1,6 +1,7 @@
 Structure,Field,Size Field?,Type,Index,Default Value,PersistIfDefault,Is2k3,Comment
 Save,easyrpg_data,f,SaveEasyRpgData,0xC8,,0,0,Additional save data written by EasyRPG Player
 SaveEasyRpgData,version,,Int32,0x01,0,0,0,Savegame version
+SaveEasyRpgData,windows,,Array<SaveEasyRpgWindow>,0x02,,0,0,User generated windows e.g. through ShowStringPicture
 SaveEventExecFrame,maniac_event_info,f,Ref<ManiacEventInfo>,0x0E,0,0,0,Event info bitfield
 SaveEventExecFrame,maniac_event_id,f,Int32,0x0F,0,0,0,Event ID
 SaveEventExecFrame,maniac_event_page_id,f,Int32,0x10,0,0,0,Page ID when it is a map event
@@ -8,6 +9,21 @@ SaveEventExecFrame,maniac_loop_info_size,f,Int32,0x11,0,0,0,Amount of loop info 
 SaveEventExecFrame,maniac_loop_info,f,Vector<Int32>,0x12,,0,0,"One group of (Current loop count, end loop value) for each identation"
 SavePicture,easyrpg_flip,f,Enum<EasyRpgFlip>,0xC8,0,0,1,How to flip the picture
 SavePicture,easyrpg_blend_mode,f,Int32,0xC9,0,0,1,Blend mode to use for blit. See Bitmap::BlendMode
+SavePicture,easyrpg_type,f,Enum<EasyRpgPictureType>,0xCA,0,0,1,Type of this picture
+SaveEasyRpgWindow,texts,f,Array<SaveEasyRpgText>,0x01,,0,0,Texts to render
+SaveEasyRpgWindow,width,f,Int32,0x02,0,0,0,Window width (px)
+SaveEasyRpgWindow,height,f,Int32,0x03,0,0,0,Window height (px)
+SaveEasyRpgWindow,system_name,f,DBString,0x04,,0,0,
+SaveEasyRpgWindow,message_stretch,f,Enum<System_Stretch>,0x05,0,0,0,
+SaveEasyRpgWindow,flags,f,SaveEasyRpgWindow_Flags,0x06,3,0,0,Various window settings
+SaveEasyRpgText,text,f,DBString,0x01,,0,0,Text to render
+SaveEasyRpgText,position_x,f,Int32,0x02,0,0,0,
+SaveEasyRpgText,position_y,f,Int32,0x03,0,0,0,
+SaveEasyRpgText,font_name,f,DBString,0x04,,0,0,Font to use for rendering
+SaveEasyRpgText,font_size,f,Int32,0x05,12,0,0,Font size
+SaveEasyRpgText,letter_spacing,f,Int32,0x06,0,0,0,Additional spacing between letters
+SaveEasyRpgText,line_spacing,f,Int32,0x07,4,0,0,Additional spacing between lines
+SaveEasyRpgText,flags,f,SaveEasyRpgText_Flags,0x08,3,0,0,Various text settings
 SaveSystem,maniac_frameskip,,Int32,0x88,0,0,0,"FatalMix Frameskip (0=None, 1=1/5, 2=1/3, 3=1/2)"
 SaveSystem,maniac_picture_limit,,Int32,0x89,0,0,0,FatalMix Picture Limit
 SaveSystem,maniac_options,,Vector<UInt8>,0x8A,,0,0,"Various FatalMix options (XX XA XB XC). A: MsgSkip OFF/RShift (0/4) B: TestPlay Keep/ON/OFF (0/2/4), C: Pause focus lost Wait/Run (0/1)"

--- a/generator/csv/flags_easyrpg.csv
+++ b/generator/csv/flags_easyrpg.csv
@@ -1,0 +1,7 @@
+Structure,Field,Is2k3
+SaveEasyRpgWindow,draw_frame,0
+SaveEasyRpgWindow,border_margin,0
+SaveEasyRpgText,draw_gradient,0
+SaveEasyRpgText,draw_shadow,0
+SaveEasyRpgText,bold,0
+SaveEasyRpgText,italic,0

--- a/generator/csv/structs_easyrpg.csv
+++ b/generator/csv/structs_easyrpg.csv
@@ -1,2 +1,4 @@
 Type,Structure,Base,Index available?
 lsd,SaveEasyRpgData,,0
+lsd,SaveEasyRpgWindow,,1
+lsd,SaveEasyRpgText,,0

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -488,10 +488,10 @@ def main(argv):
     global structs, structs_flat, sfields, enums, flags, functions, constants, headers
     global chunk_tmpl, lcf_struct_tmpl, rpg_header_tmpl, rpg_source_tmpl, flags_tmpl, enums_tmpl, fwd_tmpl, fwd_struct_tmpl
 
-    structs, structs_flat = get_structs('structs.csv','structs_easyrpg.csv')
-    sfields = get_fields('fields.csv','fields_easyrpg.csv')
-    enums = get_enums('enums.csv','enums_easyrpg.csv')
-    flags = get_flags('flags.csv')
+    structs, structs_flat = get_structs('structs.csv', 'structs_easyrpg.csv')
+    sfields = get_fields('fields.csv', 'fields_easyrpg.csv')
+    enums = get_enums('enums.csv', 'enums_easyrpg.csv')
+    flags = get_flags('flags.csv', 'flags_easyrpg.csv')
     functions = get_functions('functions.csv')
     constants = get_constants()
     headers = get_headers()

--- a/src/generated/fwd_struct_impl.h
+++ b/src/generated/fwd_struct_impl.h
@@ -198,6 +198,16 @@ template <>
 Field<rpg::SaveEasyRpgData> const* Struct<rpg::SaveEasyRpgData>::fields[];
 
 template <>
+const char* const Struct<rpg::SaveEasyRpgText>::name;
+template <>
+Field<rpg::SaveEasyRpgText> const* Struct<rpg::SaveEasyRpgText>::fields[];
+
+template <>
+const char* const Struct<rpg::SaveEasyRpgWindow>::name;
+template <>
+Field<rpg::SaveEasyRpgWindow> const* Struct<rpg::SaveEasyRpgWindow>::fields[];
+
+template <>
 const char* const Struct<rpg::SaveEventExecFrame>::name;
 template <>
 Field<rpg::SaveEventExecFrame> const* Struct<rpg::SaveEventExecFrame>::fields[];

--- a/src/generated/lcf/lsd/chunks.h
+++ b/src/generated/lcf/lsd/chunks.h
@@ -317,7 +317,9 @@ namespace LSD_Reader {
 			/** How to flip the picture */
 			easyrpg_flip = 0xC8,
 			/** Blend mode to use for blit. See Bitmap::BlendMode */
-			easyrpg_blend_mode = 0xC9
+			easyrpg_blend_mode = 0xC9,
+			/** Type of this picture */
+			easyrpg_type = 0xCA
 		};
 	};
 	struct ChunkSavePartyLocation {
@@ -985,7 +987,45 @@ namespace LSD_Reader {
 	struct ChunkSaveEasyRpgData {
 		enum Index {
 			/** Savegame version */
-			version = 0x01
+			version = 0x01,
+			/** User generated windows e.g. through ShowStringPicture */
+			windows = 0x02
+		};
+	};
+	struct ChunkSaveEasyRpgWindow {
+		enum Index {
+			/** Texts to render */
+			texts = 0x01,
+			/** Window width (px) */
+			width = 0x02,
+			/** Window height (px) */
+			height = 0x03,
+			/**  */
+			system_name = 0x04,
+			/**  */
+			message_stretch = 0x05,
+			/** Various window settings */
+			flags = 0x06
+		};
+	};
+	struct ChunkSaveEasyRpgText {
+		enum Index {
+			/** Text to render */
+			text = 0x01,
+			/**  */
+			position_x = 0x02,
+			/**  */
+			position_y = 0x03,
+			/** Font to use for rendering */
+			font_name = 0x04,
+			/** Font size */
+			font_size = 0x05,
+			/** Additional spacing between letters */
+			letter_spacing = 0x06,
+			/** Additional spacing between lines */
+			line_spacing = 0x07,
+			/** Various text settings */
+			flags = 0x08
 		};
 	};
 }

--- a/src/generated/lcf/rpg/fwd.h
+++ b/src/generated/lcf/rpg/fwd.h
@@ -51,6 +51,8 @@ namespace rpg {
 	class SaveActor;
 	class SaveCommonEvent;
 	class SaveEasyRpgData;
+	class SaveEasyRpgText;
+	class SaveEasyRpgWindow;
 	class SaveEventExecFrame;
 	class SaveEventExecState;
 	class SaveInventory;

--- a/src/generated/lcf/rpg/saveeasyrpgdata.h
+++ b/src/generated/lcf/rpg/saveeasyrpgdata.h
@@ -14,6 +14,8 @@
 
 // Headers
 #include <stdint.h>
+#include <vector>
+#include "lcf/rpg/saveeasyrpgwindow.h"
 #include "lcf/context.h"
 #include <ostream>
 #include <type_traits>
@@ -26,10 +28,12 @@ namespace rpg {
 	class SaveEasyRpgData {
 	public:
 		int32_t version = 0;
+		std::vector<SaveEasyRpgWindow> windows;
 	};
 
 	inline bool operator==(const SaveEasyRpgData& l, const SaveEasyRpgData& r) {
-		return l.version == r.version;
+		return l.version == r.version
+		&& l.windows == r.windows;
 	}
 
 	inline bool operator!=(const SaveEasyRpgData& l, const SaveEasyRpgData& r) {
@@ -40,6 +44,10 @@ namespace rpg {
 
 	template <typename F, typename ParentCtx = Context<void,void>>
 	void ForEachString(SaveEasyRpgData& obj, const F& f, const ParentCtx* parent_ctx = nullptr) {
+		for (int i = 0; i < static_cast<int>(obj.windows.size()); ++i) {
+			const auto ctx2 = Context<SaveEasyRpgData, ParentCtx>{ "windows", i, &obj, parent_ctx };
+			ForEachString(obj.windows[i], f, &ctx2);
+		}
 		(void)obj;
 		(void)f;
 		(void)parent_ctx;

--- a/src/generated/lcf/rpg/saveeasyrpgtext.h
+++ b/src/generated/lcf/rpg/saveeasyrpgtext.h
@@ -1,0 +1,94 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2021 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+#ifndef LCF_RPG_SAVEEASYRPGTEXT_H
+#define LCF_RPG_SAVEEASYRPGTEXT_H
+
+// Headers
+#include <array>
+#include <stdint.h>
+#include "lcf/dbstring.h"
+#include "lcf/context.h"
+#include <ostream>
+#include <type_traits>
+
+/**
+ * rpg::SaveEasyRpgText class.
+ */
+namespace lcf {
+namespace rpg {
+	class SaveEasyRpgText {
+	public:
+		DBString text;
+		int32_t position_x = 0;
+		int32_t position_y = 0;
+		DBString font_name;
+		int32_t font_size = 12;
+		int32_t letter_spacing = 0;
+		int32_t line_spacing = 4;
+		struct Flags {
+			union {
+				struct {
+					bool draw_gradient;
+					bool draw_shadow;
+					bool bold;
+					bool italic;
+				};
+				std::array<bool, 4> flags;
+			};
+			//TODO: Should try to switch to member initializers when we upgrade to VS2017.
+			Flags() noexcept: draw_gradient(true), draw_shadow(true), bold(false), italic(false)
+			{}
+		} flags;
+	};
+
+	inline bool operator==(const SaveEasyRpgText::Flags& l, const SaveEasyRpgText::Flags& r) {
+		return l.flags == r.flags;
+	}
+
+	inline bool operator!=(const SaveEasyRpgText::Flags& l, const SaveEasyRpgText::Flags& r) {
+		return !(l == r);
+	}
+
+	std::ostream& operator<<(std::ostream& os, const SaveEasyRpgText::Flags& obj);
+
+	inline bool operator==(const SaveEasyRpgText& l, const SaveEasyRpgText& r) {
+		return l.text == r.text
+		&& l.position_x == r.position_x
+		&& l.position_y == r.position_y
+		&& l.font_name == r.font_name
+		&& l.font_size == r.font_size
+		&& l.letter_spacing == r.letter_spacing
+		&& l.line_spacing == r.line_spacing
+		&& l.flags == r.flags;
+	}
+
+	inline bool operator!=(const SaveEasyRpgText& l, const SaveEasyRpgText& r) {
+		return !(l == r);
+	}
+
+	std::ostream& operator<<(std::ostream& os, const SaveEasyRpgText& obj);
+
+	template <typename F, typename ParentCtx = Context<void,void>>
+	void ForEachString(SaveEasyRpgText& obj, const F& f, const ParentCtx* parent_ctx = nullptr) {
+		const auto ctx1 = Context<SaveEasyRpgText, ParentCtx>{ "text", -1, &obj, parent_ctx };
+		f(obj.text, ctx1);
+		const auto ctx4 = Context<SaveEasyRpgText, ParentCtx>{ "font_name", -1, &obj, parent_ctx };
+		f(obj.font_name, ctx4);
+		(void)obj;
+		(void)f;
+		(void)parent_ctx;
+	}
+
+} // namespace rpg
+} // namespace lcf
+
+#endif

--- a/src/generated/lcf/rpg/saveeasyrpgwindow.h
+++ b/src/generated/lcf/rpg/saveeasyrpgwindow.h
@@ -1,0 +1,94 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2021 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+#ifndef LCF_RPG_SAVEEASYRPGWINDOW_H
+#define LCF_RPG_SAVEEASYRPGWINDOW_H
+
+// Headers
+#include <array>
+#include <stdint.h>
+#include <vector>
+#include "lcf/dbstring.h"
+#include "lcf/enum_tags.h"
+#include "lcf/rpg/saveeasyrpgtext.h"
+#include "lcf/context.h"
+#include <ostream>
+#include <type_traits>
+
+/**
+ * rpg::SaveEasyRpgWindow class.
+ */
+namespace lcf {
+namespace rpg {
+	class SaveEasyRpgWindow {
+	public:
+		int ID = 0;
+		std::vector<SaveEasyRpgText> texts;
+		int32_t width = 0;
+		int32_t height = 0;
+		DBString system_name;
+		int32_t message_stretch = 0;
+		struct Flags {
+			union {
+				struct {
+					bool draw_frame;
+					bool border_margin;
+				};
+				std::array<bool, 2> flags;
+			};
+			//TODO: Should try to switch to member initializers when we upgrade to VS2017.
+			Flags() noexcept: draw_frame(true), border_margin(true)
+			{}
+		} flags;
+	};
+
+	inline bool operator==(const SaveEasyRpgWindow::Flags& l, const SaveEasyRpgWindow::Flags& r) {
+		return l.flags == r.flags;
+	}
+
+	inline bool operator!=(const SaveEasyRpgWindow::Flags& l, const SaveEasyRpgWindow::Flags& r) {
+		return !(l == r);
+	}
+
+	std::ostream& operator<<(std::ostream& os, const SaveEasyRpgWindow::Flags& obj);
+
+	inline bool operator==(const SaveEasyRpgWindow& l, const SaveEasyRpgWindow& r) {
+		return l.texts == r.texts
+		&& l.width == r.width
+		&& l.height == r.height
+		&& l.system_name == r.system_name
+		&& l.message_stretch == r.message_stretch
+		&& l.flags == r.flags;
+	}
+
+	inline bool operator!=(const SaveEasyRpgWindow& l, const SaveEasyRpgWindow& r) {
+		return !(l == r);
+	}
+
+	std::ostream& operator<<(std::ostream& os, const SaveEasyRpgWindow& obj);
+
+	template <typename F, typename ParentCtx = Context<void,void>>
+	void ForEachString(SaveEasyRpgWindow& obj, const F& f, const ParentCtx* parent_ctx = nullptr) {
+		for (int i = 0; i < static_cast<int>(obj.texts.size()); ++i) {
+			const auto ctx1 = Context<SaveEasyRpgWindow, ParentCtx>{ "texts", i, &obj, parent_ctx };
+			ForEachString(obj.texts[i], f, &ctx1);
+		}
+		const auto ctx4 = Context<SaveEasyRpgWindow, ParentCtx>{ "system_name", -1, &obj, parent_ctx };
+		f(obj.system_name, ctx4);
+		(void)obj;
+		(void)f;
+		(void)parent_ctx;
+	}
+
+} // namespace rpg
+} // namespace lcf
+
+#endif

--- a/src/generated/lcf/rpg/savepicture.h
+++ b/src/generated/lcf/rpg/savepicture.h
@@ -94,6 +94,14 @@ namespace rpg {
 			"y",
 			"both"
 		);
+		enum EasyRpgType {
+			EasyRpgType_default = 0,
+			EasyRpgType_window = 1
+		};
+		static constexpr auto kEasyRpgTypeTags = lcf::makeEnumTags<EasyRpgType>(
+			"default",
+			"window"
+		);
 
 		int ID = 0;
 		std::string name;
@@ -152,6 +160,7 @@ namespace rpg {
 		int32_t current_waver = 0;
 		int32_t easyrpg_flip = 0;
 		int32_t easyrpg_blend_mode = 0;
+		int32_t easyrpg_type = 0;
 	};
 	inline std::ostream& operator<<(std::ostream& os, SavePicture::Effect code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -166,6 +175,10 @@ namespace rpg {
 		return os;
 	}
 	inline std::ostream& operator<<(std::ostream& os, SavePicture::EasyRpgFlip code) {
+		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
+		return os;
+	}
+	inline std::ostream& operator<<(std::ostream& os, SavePicture::EasyRpgType code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
 		return os;
 	}
@@ -220,7 +233,8 @@ namespace rpg {
 		&& l.current_rotation == r.current_rotation
 		&& l.current_waver == r.current_waver
 		&& l.easyrpg_flip == r.easyrpg_flip
-		&& l.easyrpg_blend_mode == r.easyrpg_blend_mode;
+		&& l.easyrpg_blend_mode == r.easyrpg_blend_mode
+		&& l.easyrpg_type == r.easyrpg_type;
 	}
 
 	inline bool operator!=(const SavePicture& l, const SavePicture& r) {

--- a/src/generated/lcf/rpg/system.h
+++ b/src/generated/lcf/rpg/system.h
@@ -129,11 +129,13 @@ namespace rpg {
 		);
 		enum Stretch {
 			Stretch_stretch = 0,
-			Stretch_tiled = 1
+			Stretch_tiled = 1,
+			Stretch_easyrpg_none = 2
 		};
 		static constexpr auto kStretchTags = lcf::makeEnumTags<Stretch>(
 			"stretch",
-			"tiled"
+			"tiled",
+			"easyrpg_none"
 		);
 		enum Font {
 			Font_gothic = 0,

--- a/src/generated/lsd_saveeasyrpgdata.cpp
+++ b/src/generated/lsd_saveeasyrpgdata.cpp
@@ -27,11 +27,19 @@ static TypedField<rpg::SaveEasyRpgData, int32_t> static_version(
 	0,
 	0
 );
+static TypedField<rpg::SaveEasyRpgData, std::vector<rpg::SaveEasyRpgWindow>> static_windows(
+	&rpg::SaveEasyRpgData::windows,
+	LSD_Reader::ChunkSaveEasyRpgData::windows,
+	"windows",
+	0,
+	0
+);
 
 
 template <>
 Field<rpg::SaveEasyRpgData> const* Struct<rpg::SaveEasyRpgData>::fields[] = {
 	&static_version,
+	&static_windows,
 	NULL
 };
 

--- a/src/generated/lsd_saveeasyrpgtext.cpp
+++ b/src/generated/lsd_saveeasyrpgtext.cpp
@@ -1,0 +1,96 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2021 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+// Headers
+#include "lcf/lsd/reader.h"
+#include "lcf/lsd/chunks.h"
+#include "reader_struct_impl.h"
+
+namespace lcf {
+
+// Read SaveEasyRpgText.
+
+template <>
+char const* const Struct<rpg::SaveEasyRpgText>::name = "SaveEasyRpgText";
+static TypedField<rpg::SaveEasyRpgText, DBString> static_text(
+	&rpg::SaveEasyRpgText::text,
+	LSD_Reader::ChunkSaveEasyRpgText::text,
+	"text",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgText, int32_t> static_position_x(
+	&rpg::SaveEasyRpgText::position_x,
+	LSD_Reader::ChunkSaveEasyRpgText::position_x,
+	"position_x",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgText, int32_t> static_position_y(
+	&rpg::SaveEasyRpgText::position_y,
+	LSD_Reader::ChunkSaveEasyRpgText::position_y,
+	"position_y",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgText, DBString> static_font_name(
+	&rpg::SaveEasyRpgText::font_name,
+	LSD_Reader::ChunkSaveEasyRpgText::font_name,
+	"font_name",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgText, int32_t> static_font_size(
+	&rpg::SaveEasyRpgText::font_size,
+	LSD_Reader::ChunkSaveEasyRpgText::font_size,
+	"font_size",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgText, int32_t> static_letter_spacing(
+	&rpg::SaveEasyRpgText::letter_spacing,
+	LSD_Reader::ChunkSaveEasyRpgText::letter_spacing,
+	"letter_spacing",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgText, int32_t> static_line_spacing(
+	&rpg::SaveEasyRpgText::line_spacing,
+	LSD_Reader::ChunkSaveEasyRpgText::line_spacing,
+	"line_spacing",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgText, rpg::SaveEasyRpgText::Flags> static_flags(
+	&rpg::SaveEasyRpgText::flags,
+	LSD_Reader::ChunkSaveEasyRpgText::flags,
+	"flags",
+	0,
+	0
+);
+
+
+template <>
+Field<rpg::SaveEasyRpgText> const* Struct<rpg::SaveEasyRpgText>::fields[] = {
+	&static_text,
+	&static_position_x,
+	&static_position_y,
+	&static_font_name,
+	&static_font_size,
+	&static_letter_spacing,
+	&static_line_spacing,
+	&static_flags,
+	NULL
+};
+
+template class Struct<rpg::SaveEasyRpgText>;
+
+} //namespace lcf

--- a/src/generated/lsd_saveeasyrpgtext_flags.h
+++ b/src/generated/lsd_saveeasyrpgtext_flags.h
@@ -1,0 +1,42 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2021 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+/*
+ * Headers
+ */
+#include "lcf/lsd/reader.h"
+#include "lcf/lsd/chunks.h"
+#include "reader_struct.h"
+
+namespace lcf {
+
+// Read SaveEasyRpgText.
+
+template <>
+char const* const Flags<rpg::SaveEasyRpgText::Flags>::name = "SaveEasyRpgText_Flags";
+
+template <>
+decltype(Flags<rpg::SaveEasyRpgText::Flags>::flag_names) Flags<rpg::SaveEasyRpgText::Flags>::flag_names = {
+	"draw_gradient",
+	"draw_shadow",
+	"bold",
+	"italic"
+};
+
+template <>
+decltype(Flags<rpg::SaveEasyRpgText::Flags>::flags_is2k3) Flags<rpg::SaveEasyRpgText::Flags>::flags_is2k3 = {
+	0,
+	0,
+	0,
+	0
+};
+
+} //namespace lcf

--- a/src/generated/lsd_saveeasyrpgwindow.cpp
+++ b/src/generated/lsd_saveeasyrpgwindow.cpp
@@ -1,0 +1,80 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2021 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+// Headers
+#include "lcf/lsd/reader.h"
+#include "lcf/lsd/chunks.h"
+#include "reader_struct_impl.h"
+
+namespace lcf {
+
+// Read SaveEasyRpgWindow.
+
+template <>
+char const* const Struct<rpg::SaveEasyRpgWindow>::name = "SaveEasyRpgWindow";
+static TypedField<rpg::SaveEasyRpgWindow, std::vector<rpg::SaveEasyRpgText>> static_texts(
+	&rpg::SaveEasyRpgWindow::texts,
+	LSD_Reader::ChunkSaveEasyRpgWindow::texts,
+	"texts",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgWindow, int32_t> static_width(
+	&rpg::SaveEasyRpgWindow::width,
+	LSD_Reader::ChunkSaveEasyRpgWindow::width,
+	"width",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgWindow, int32_t> static_height(
+	&rpg::SaveEasyRpgWindow::height,
+	LSD_Reader::ChunkSaveEasyRpgWindow::height,
+	"height",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgWindow, DBString> static_system_name(
+	&rpg::SaveEasyRpgWindow::system_name,
+	LSD_Reader::ChunkSaveEasyRpgWindow::system_name,
+	"system_name",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgWindow, int32_t> static_message_stretch(
+	&rpg::SaveEasyRpgWindow::message_stretch,
+	LSD_Reader::ChunkSaveEasyRpgWindow::message_stretch,
+	"message_stretch",
+	0,
+	0
+);
+static TypedField<rpg::SaveEasyRpgWindow, rpg::SaveEasyRpgWindow::Flags> static_flags(
+	&rpg::SaveEasyRpgWindow::flags,
+	LSD_Reader::ChunkSaveEasyRpgWindow::flags,
+	"flags",
+	0,
+	0
+);
+
+
+template <>
+Field<rpg::SaveEasyRpgWindow> const* Struct<rpg::SaveEasyRpgWindow>::fields[] = {
+	&static_texts,
+	&static_width,
+	&static_height,
+	&static_system_name,
+	&static_message_stretch,
+	&static_flags,
+	NULL
+};
+
+template class Struct<rpg::SaveEasyRpgWindow>;
+
+} //namespace lcf

--- a/src/generated/lsd_saveeasyrpgwindow_flags.h
+++ b/src/generated/lsd_saveeasyrpgwindow_flags.h
@@ -1,0 +1,38 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2021 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+/*
+ * Headers
+ */
+#include "lcf/lsd/reader.h"
+#include "lcf/lsd/chunks.h"
+#include "reader_struct.h"
+
+namespace lcf {
+
+// Read SaveEasyRpgWindow.
+
+template <>
+char const* const Flags<rpg::SaveEasyRpgWindow::Flags>::name = "SaveEasyRpgWindow_Flags";
+
+template <>
+decltype(Flags<rpg::SaveEasyRpgWindow::Flags>::flag_names) Flags<rpg::SaveEasyRpgWindow::Flags>::flag_names = {
+	"draw_frame",
+	"border_margin"
+};
+
+template <>
+decltype(Flags<rpg::SaveEasyRpgWindow::Flags>::flags_is2k3) Flags<rpg::SaveEasyRpgWindow::Flags>::flags_is2k3 = {
+	0,
+	0
+};
+
+} //namespace lcf

--- a/src/generated/lsd_savepicture.cpp
+++ b/src/generated/lsd_savepicture.cpp
@@ -300,6 +300,13 @@ static TypedField<rpg::SavePicture, int32_t> static_easyrpg_blend_mode(
 	0,
 	1
 );
+static TypedField<rpg::SavePicture, int32_t> static_easyrpg_type(
+	&rpg::SavePicture::easyrpg_type,
+	LSD_Reader::ChunkSavePicture::easyrpg_type,
+	"easyrpg_type",
+	0,
+	1
+);
 
 
 template <>
@@ -344,6 +351,7 @@ Field<rpg::SavePicture> const* Struct<rpg::SavePicture>::fields[] = {
 	&static_current_waver,
 	&static_easyrpg_flip,
 	&static_easyrpg_blend_mode,
+	&static_easyrpg_type,
 	NULL
 };
 

--- a/src/generated/rpg_enums.cpp
+++ b/src/generated/rpg_enums.cpp
@@ -99,6 +99,7 @@ constexpr decltype(SavePicture::kEffectTags) SavePicture::kEffectTags;
 constexpr decltype(SavePicture::kMapLayerTags) SavePicture::kMapLayerTags;
 constexpr decltype(SavePicture::kBattleLayerTags) SavePicture::kBattleLayerTags;
 constexpr decltype(SavePicture::kEasyRpgFlipTags) SavePicture::kEasyRpgFlipTags;
+constexpr decltype(SavePicture::kEasyRpgTypeTags) SavePicture::kEasyRpgTypeTags;
 constexpr decltype(SavePartyLocation::kVehicleTypeTags) SavePartyLocation::kVehicleTypeTags;
 constexpr decltype(SavePartyLocation::kPanStateTags) SavePartyLocation::kPanStateTags;
 constexpr decltype(SaveVehicleLocation::kVehicleTypeTags) SaveVehicleLocation::kVehicleTypeTags;

--- a/src/generated/rpg_saveeasyrpgdata.cpp
+++ b/src/generated/rpg_saveeasyrpgdata.cpp
@@ -18,6 +18,11 @@ namespace rpg {
 std::ostream& operator<<(std::ostream& os, const SaveEasyRpgData& obj) {
 	os << "SaveEasyRpgData{";
 	os << "version="<< obj.version;
+	os << ", windows=";
+	for (size_t i = 0; i < obj.windows.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.windows[i];
+	}
+	os << "]";
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_saveeasyrpgtext.cpp
+++ b/src/generated/rpg_saveeasyrpgtext.cpp
@@ -1,0 +1,41 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2021 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+// Headers
+#include "lcf/rpg/saveeasyrpgtext.h"
+
+namespace lcf {
+namespace rpg {
+
+std::ostream& operator<<(std::ostream& os, const SaveEasyRpgText::Flags& obj) {
+	for (size_t i = 0; i < obj.flags.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.flags[i];
+	}
+	os << "]";
+	return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const SaveEasyRpgText& obj) {
+	os << "SaveEasyRpgText{";
+	os << "text="<< obj.text;
+	os << ", position_x="<< obj.position_x;
+	os << ", position_y="<< obj.position_y;
+	os << ", font_name="<< obj.font_name;
+	os << ", font_size="<< obj.font_size;
+	os << ", letter_spacing="<< obj.letter_spacing;
+	os << ", line_spacing="<< obj.line_spacing;
+	os << ", flags="<< obj.flags;
+	os << "}";
+	return os;
+}
+
+} // namespace rpg
+} // namespace lcf

--- a/src/generated/rpg_saveeasyrpgwindow.cpp
+++ b/src/generated/rpg_saveeasyrpgwindow.cpp
@@ -1,0 +1,43 @@
+/* !!!! GENERATED FILE - DO NOT EDIT !!!!
+ * --------------------------------------
+ *
+ * This file is part of liblcf. Copyright (c) 2021 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+// Headers
+#include "lcf/rpg/saveeasyrpgwindow.h"
+
+namespace lcf {
+namespace rpg {
+
+std::ostream& operator<<(std::ostream& os, const SaveEasyRpgWindow::Flags& obj) {
+	for (size_t i = 0; i < obj.flags.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.flags[i];
+	}
+	os << "]";
+	return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const SaveEasyRpgWindow& obj) {
+	os << "SaveEasyRpgWindow{";
+	os << "texts=";
+	for (size_t i = 0; i < obj.texts.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.texts[i];
+	}
+	os << "]";
+	os << ", width="<< obj.width;
+	os << ", height="<< obj.height;
+	os << ", system_name="<< obj.system_name;
+	os << ", message_stretch="<< obj.message_stretch;
+	os << ", flags="<< obj.flags;
+	os << "}";
+	return os;
+}
+
+} // namespace rpg
+} // namespace lcf

--- a/src/generated/rpg_savepicture.cpp
+++ b/src/generated/rpg_savepicture.cpp
@@ -65,6 +65,7 @@ std::ostream& operator<<(std::ostream& os, const SavePicture& obj) {
 	os << ", current_waver="<< obj.current_waver;
 	os << ", easyrpg_flip="<< obj.easyrpg_flip;
 	os << ", easyrpg_blend_mode="<< obj.easyrpg_blend_mode;
+	os << ", easyrpg_type="<< obj.easyrpg_type;
 	os << "}";
 	return os;
 }

--- a/src/reader_flags.cpp
+++ b/src/reader_flags.cpp
@@ -38,7 +38,7 @@ void Flags<S>::ReadLcf(S& obj, LcfReader& stream, uint32_t length) {
 			stream.Read(byte);
 			bitidx = 0;
 		}
-		obj.flags[i] |= (byte >> bitidx) & 1;
+		obj.flags[i] = (byte >> bitidx) & 1;
 		++bitidx;
 	}
 #ifdef LCF_DEBUG_TRACE

--- a/src/reader_flags.cpp
+++ b/src/reader_flags.cpp
@@ -17,6 +17,8 @@
 #include "ldb_terrain_flags.h"
 #include "lmu_eventpagecondition_flags.h"
 #include "lsd_savepicture_flags.h"
+#include "lsd_saveeasyrpgtext_flags.h"
+#include "lsd_saveeasyrpgwindow_flags.h"
 
 namespace lcf {
 // Templates
@@ -141,9 +143,12 @@ void Flags<S>::BeginXml(S& obj, XmlReader& stream) {
 #pragma warning (disable : 4661)
 #endif
 
+// Do not forget to add new Flags here
 template class Flags<rpg::TroopPageCondition::Flags>;
 template class Flags<rpg::EventPageCondition::Flags>;
 template class Flags<rpg::Terrain::Flags>;
 template class Flags<rpg::SavePicture::Flags>;
+template class Flags<rpg::SaveEasyRpgText::Flags>;
+template class Flags<rpg::SaveEasyRpgWindow::Flags>;
 
 } //namespace lcf

--- a/src/reader_struct.h
+++ b/src/reader_struct.h
@@ -36,6 +36,8 @@
 #include "lcf/rpg/rect.h"
 #include "lcf/rpg/savepicture.h"
 #include "lcf/rpg/terms.h"
+#include "lcf/rpg/saveeasyrpgtext.h"
+#include "lcf/rpg/saveeasyrpgwindow.h"
 
 namespace lcf {
 
@@ -61,10 +63,13 @@ struct TypeCategory {
 	static const Category::Index value = Category::Struct;
 };
 
+// Do not forget to add new Flags here
 template <> struct TypeCategory<rpg::TroopPageCondition::Flags>	{ static const Category::Index value = Category::Flags; };
 template <> struct TypeCategory<rpg::EventPageCondition::Flags>	{ static const Category::Index value = Category::Flags; };
-template <> struct TypeCategory<rpg::Terrain::Flags>				{ static const Category::Index value = Category::Flags; };
-template <> struct TypeCategory<rpg::SavePicture::Flags>			{ static const Category::Index value = Category::Flags; };
+template <> struct TypeCategory<rpg::Terrain::Flags>			{ static const Category::Index value = Category::Flags; };
+template <> struct TypeCategory<rpg::SavePicture::Flags>		{ static const Category::Index value = Category::Flags; };
+template <> struct TypeCategory<rpg::SaveEasyRpgText::Flags>	{ static const Category::Index value = Category::Flags; };
+template <> struct TypeCategory<rpg::SaveEasyRpgWindow::Flags>	{ static const Category::Index value = Category::Flags; };
 
 template <> struct TypeCategory<rpg::Equipment>					{ static const Category::Index value = Category::RawStruct; };
 template <> struct TypeCategory<rpg::EventCommand>				{ static const Category::Index value = Category::RawStruct; };


### PR DESCRIPTION
This is implemented with a new data structure EasyRpgWindow that contains EasyRpgText.

When we ever add our own Window event functions these will provide a good baseline.

### Design

The window has the same ID as the picture. The picture receives a new field ``easyrpg_type`` to indicate if anything is attached to the picture.

The savegame receives a new chunk "2" to the EasyRPG data: ``Array<SaveEasyRpgWindow>``.

A ``SaveEasyRpgWindow`` describes a single window. Right now only ShowStringPic can create them.

A Window has styling information and a list of texts (``SaveEasyRpgText``).

Window styling stuff: width, height, system_name, message_stretch, flags like "draw_frame".

``SaveEasyRpgText`` contains stuff like "text" (obviously), x, y, font, font size, letter spacing (unsupported), line spacing, flags like italic or bold.

