### PR TITLE
Amend #448. CMake: INSTALL_INTERFACE must be CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ target_include_directories(
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/generated>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # Optimize floating point math functions into intrinsics and don't check or set errno (i.e. sqrt(-1))


### PR DESCRIPTION
Verified this now by looking in build.ninja

Player build tested on a Linux with liblcf uninstalled and on macOS.
