### PR TITLE
CMake config: 3rd try

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /autom4te.cache/
 /builds/autoconf/
 !/builds/autoconf/m4/m4_ax_pkg_check_modules.m4
+!/builds/autoconf/liblcf-config.cmake.in
 /lcf2xml
 /liblcf-*/
 .deps/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,8 @@ foreach(SG LDB LMT LMU LSD RPG THIRD_PARTY)
 endforeach()
 
 # includes
+include(GNUInstallDirs)
+
 target_include_directories(
 	lcf PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
@@ -367,7 +369,6 @@ target_sources(lcf PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src/lcf/config.h)
 set_property(TARGET lcf PROPERTY SOVERSION 0)
 
 # installation
-include(GNUInstallDirs)
 
 # pkg-config file generation
 set(LCF_LIBDIR ${CMAKE_INSTALL_LIBDIR})

--- a/builds/autoconf/liblcf-config.cmake.in
+++ b/builds/autoconf/liblcf-config.cmake.in
@@ -1,9 +1,19 @@
-# For simplicity reasons depend on pkg-config when liblcf was compiled with autotools
+# For "simplicity" reasons depend on pkg-config when liblcf was compiled with autotools
 
 include(CMakeFindDependencyMacro)
 
 find_dependency(PkgConfig REQUIRED QUIET)
 
 pkg_check_modules(liblcf REQUIRED QUIET IMPORTED_TARGET liblcf=@PACKAGE_VERSION@)
+
+get_property(library_name TARGET PkgConfig::liblcf PROPERTY INTERFACE_LINK_LIBRARIES)
+
+if (library_name MATCHES ".a$")
+       list(REMOVE_ITEM liblcf_STATIC_LIBRARIES lcf)
+       set_property(TARGET PkgConfig::liblcf APPEND PROPERTY
+               INTERFACE_LINK_LIBRARIES "${liblcf_STATIC_LIBRARIES}")
+       set_property(TARGET PkgConfig::liblcf APPEND PROPERTY
+               INTERFACE_LINK_DIRECTORIES "${liblcf_STATIC_LIBRARY_DIRS}")
+endif()
 
 add_library(liblcf::liblcf ALIAS PkgConfig::liblcf)


### PR DESCRIPTION
Tested now the following combinations:

- liblcf build with autotools
- liblcf build with CMake

For both static and shared.

Then compiled Player:

- CMake with liblcf autotools: Both "pkg-config" and "pkg-config --static" tested (4 builds)
- CMake with liblcf CMake (2 builds)

Everything works. This stuff is so dumb.