### PR TITLE
Add "codepage" field to easyrpg_data

### DIFF
--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -1,7 +1,8 @@
 Structure,Field,Size Field?,Type,Index,Default Value,PersistIfDefault,Is2k3,Comment
 Save,easyrpg_data,f,SaveEasyRpgData,0xC8,,0,0,Additional save data written by EasyRPG Player
 SaveEasyRpgData,version,,Int32,0x01,0,0,0,Savegame version
-SaveEasyRpgData,windows,,Array<SaveEasyRpgWindow>,0x02,,0,0,User generated windows e.g. through ShowStringPicture
+SaveEasyRpgData,codepage,,Int32,0x02,0,0,0,Codepage used to store text in the savegame data
+SaveEasyRpgData,windows,,Array<SaveEasyRpgWindow>,0x64,,0,0,User generated windows e.g. through ShowStringPicture
 SaveEventExecFrame,maniac_event_info,f,Ref<ManiacEventInfo>,0x0E,0,0,0,Event info bitfield
 SaveEventExecFrame,maniac_event_id,f,Int32,0x0F,0,0,0,Event ID
 SaveEventExecFrame,maniac_event_page_id,f,Int32,0x10,0,0,0,Page ID when it is a map event

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -41,6 +41,11 @@ static std::string filterUtf8Compatible(std::string enc) {
 		return "";
 	}
 #endif
+
+	if (enc == "utf-8" || enc == "UTF-8" || enc == "65001") {
+		return "";
+	}
+
 	return enc;
 }
 
@@ -76,6 +81,7 @@ void Encoder::Init() {
 	if (_encoding.empty()) {
 		return;
 	}
+
 #if LCF_SUPPORT_ICU
 	auto code_page = atoi(_encoding.c_str());
 	const auto& storage_encoding = code_page > 0

--- a/src/generated/lcf/lsd/chunks.h
+++ b/src/generated/lcf/lsd/chunks.h
@@ -988,8 +988,10 @@ namespace LSD_Reader {
 		enum Index {
 			/** Savegame version */
 			version = 0x01,
+			/** Codepage used to store text in the savegame data */
+			codepage = 0x02,
 			/** User generated windows e.g. through ShowStringPicture */
-			windows = 0x02
+			windows = 0x64
 		};
 	};
 	struct ChunkSaveEasyRpgWindow {

--- a/src/generated/lcf/rpg/saveeasyrpgdata.h
+++ b/src/generated/lcf/rpg/saveeasyrpgdata.h
@@ -28,11 +28,13 @@ namespace rpg {
 	class SaveEasyRpgData {
 	public:
 		int32_t version = 0;
+		int32_t codepage = 0;
 		std::vector<SaveEasyRpgWindow> windows;
 	};
 
 	inline bool operator==(const SaveEasyRpgData& l, const SaveEasyRpgData& r) {
 		return l.version == r.version
+		&& l.codepage == r.codepage
 		&& l.windows == r.windows;
 	}
 
@@ -45,8 +47,8 @@ namespace rpg {
 	template <typename F, typename ParentCtx = Context<void,void>>
 	void ForEachString(SaveEasyRpgData& obj, const F& f, const ParentCtx* parent_ctx = nullptr) {
 		for (int i = 0; i < static_cast<int>(obj.windows.size()); ++i) {
-			const auto ctx2 = Context<SaveEasyRpgData, ParentCtx>{ "windows", i, &obj, parent_ctx };
-			ForEachString(obj.windows[i], f, &ctx2);
+			const auto ctx3 = Context<SaveEasyRpgData, ParentCtx>{ "windows", i, &obj, parent_ctx };
+			ForEachString(obj.windows[i], f, &ctx3);
 		}
 		(void)obj;
 		(void)f;

--- a/src/generated/lsd_saveeasyrpgdata.cpp
+++ b/src/generated/lsd_saveeasyrpgdata.cpp
@@ -27,6 +27,13 @@ static TypedField<rpg::SaveEasyRpgData, int32_t> static_version(
 	0,
 	0
 );
+static TypedField<rpg::SaveEasyRpgData, int32_t> static_codepage(
+	&rpg::SaveEasyRpgData::codepage,
+	LSD_Reader::ChunkSaveEasyRpgData::codepage,
+	"codepage",
+	0,
+	0
+);
 static TypedField<rpg::SaveEasyRpgData, std::vector<rpg::SaveEasyRpgWindow>> static_windows(
 	&rpg::SaveEasyRpgData::windows,
 	LSD_Reader::ChunkSaveEasyRpgData::windows,
@@ -39,6 +46,7 @@ static TypedField<rpg::SaveEasyRpgData, std::vector<rpg::SaveEasyRpgWindow>> sta
 template <>
 Field<rpg::SaveEasyRpgData> const* Struct<rpg::SaveEasyRpgData>::fields[] = {
 	&static_version,
+	&static_codepage,
 	&static_windows,
 	NULL
 };

--- a/src/generated/rpg_saveeasyrpgdata.cpp
+++ b/src/generated/rpg_saveeasyrpgdata.cpp
@@ -18,6 +18,7 @@ namespace rpg {
 std::ostream& operator<<(std::ostream& os, const SaveEasyRpgData& obj) {
 	os << "SaveEasyRpgData{";
 	os << "version="<< obj.version;
+	os << ", codepage="<< obj.codepage;
 	os << ", windows=";
 	for (size_t i = 0; i < obj.windows.size(); ++i) {
 		os << (i == 0 ? "[" : ", ") << obj.windows[i];

--- a/src/lcf/lsd/reader.h
+++ b/src/lcf/lsd/reader.h
@@ -42,7 +42,7 @@ namespace LSD_Reader {
 	/**
 	 * Increment the save save_count and update the timestamp.
 	 */
-	void PrepareSave(rpg::Save& save, int32_t version = 0);
+	void PrepareSave(rpg::Save& save, int32_t version = 0, int32_t codepage = 0);
 
 	/**
 	 * Loads Savegame.


### PR DESCRIPTION
This allows specifying an encoding for the savegame. Useful for the saving of translated games to prevent data loss.

Usage on Player side:

```diff
diff --git a/src/scene_save.cpp b/src/scene_save.cpp
index ca470de00..97aa49d30 100644
--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -16,6 +16,7 @@
  */
 
 // Headers
+#include "translation.h"
 #include <sstream>
 
 #ifdef EMSCRIPTEN
@@ -124,7 +125,10 @@ bool Scene_Save::Save(std::ostream& os, int slot_id, bool prepare_save) {
 	Game_Map::PrepareSave(save);
 
 	if (prepare_save) {
-		lcf::LSD_Reader::PrepareSave(save, PLAYER_SAVEGAME_VERSION);
+		// When a translation is loaded always store in Unicode to prevent data loss
+		int codepage = Tr::HasActiveTranslation() ? 65001 : 0;
+
+		lcf::LSD_Reader::PrepareSave(save, PLAYER_SAVEGAME_VERSION, codepage);
 		Main_Data::game_system->IncSaveCount();
 	}
```