### PR TITLE
Codepage chunk 2nd try / String Picture XML Fix

### DIFF
--- a/src/lsd_reader.cpp
+++ b/src/lsd_reader.cpp
@@ -106,6 +106,7 @@ std::unique_ptr<rpg::Save> LSD_Reader::Load(std::istream& filestream, StringView
 			LcfReader::SetError("Couldn't parse save file.\n");
 			return std::unique_ptr<rpg::Save>();
 		}
+		save.reset(new rpg::Save());
 		Struct<rpg::Save>::ReadLcf(*save, reader2);
 	}
 

--- a/src/writer_xml.cpp
+++ b/src/writer_xml.cpp
@@ -85,8 +85,6 @@ void XmlWriter::WriteString(StringView val) {
 				break;
 			case '\n':
 				stream.put(c);
-				at_bol = true;
-				Indent();
 				break;
 			case '\r':
 			case '\t':


### PR DESCRIPTION
Indent broke String Pictures. This shouldn't break anything as nothing else can contain linebreaks, except if you mess with the data.

![image](https://user-images.githubusercontent.com/1331889/225387652-3ef422f4-5385-4856-a32f-02d314b887be.png)

Reported by @florianessl thx