### PR TITLE
Support Vector<DBString>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CMAKE_CXX_EXTENSIONS ON)
 # lcf library files
 set(LCF_SOURCES
 	src/dbarray.cpp
+	src/dbstring_struct.cpp
 	src/encoder.cpp
 	src/ini.cpp
 	src/inireader.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ liblcf_la_LDFLAGS = \
 	-no-undefined
 liblcf_la_SOURCES = \
 	src/dbarray.cpp \
+	src/dbstring_struct.cpp \
 	src/encoder.cpp \
 	src/ini.cpp \
 	src/inireader.cpp \

--- a/generator/csv/fields.csv
+++ b/generator/csv/fields.csv
@@ -589,7 +589,7 @@ Database,animations,f,Array<Animation>,0x13,,1,0,rpg::Animation
 Database,chipsets,f,Array<Chipset>,0x14,,1,0,rpg::Chipset
 Database,terms,f,Terms,0x15,,1,0,rpg::Terms
 Database,system,f,System,0x16,,1,0,rpg::System
-Database,switches,f,Array<Switch>,0x17,,1,0,rpg::Switchs
+Database,switches,f,Array<Switch>,0x17,,1,0,rpg::Switches
 Database,variables,f,Array<Variable>,0x18,,1,0,rpg::Variables
 Database,commonevents,f,Array<CommonEvent>,0x19,,1,0,rpg::CommonEvent
 Database,version,f,DatabaseVersion,0x1A,0,0,0,Indicates version of database. When 1 the database was converted to RPG Maker 2000 v1.61

--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -25,6 +25,7 @@ SaveEasyRpgText,font_size,f,Int32,0x05,12,0,0,Font size
 SaveEasyRpgText,letter_spacing,f,Int32,0x06,0,0,0,Additional spacing between letters
 SaveEasyRpgText,line_spacing,f,Int32,0x07,4,0,0,Additional spacing between lines
 SaveEasyRpgText,flags,f,SaveEasyRpgText_Flags,0x08,3,0,0,Various text settings
+SaveSystem,maniac_strings,f,Vector<DBString>,0x24,,0,0,rpg::Strings
 SaveSystem,maniac_frameskip,,Int32,0x88,0,0,0,"FatalMix Frameskip (0=None, 1=1/5, 2=1/3, 3=1/2)"
 SaveSystem,maniac_picture_limit,,Int32,0x89,0,0,0,FatalMix Picture Limit
 SaveSystem,maniac_options,,Vector<UInt8>,0x8A,,0,0,"Various FatalMix options (XX XA XB XC). A: MsgSkip OFF/RShift (0/4) B: TestPlay Keep/ON/OFF (0/2/4), C: Pause focus lost Wait/Run (0/1)"

--- a/src/dbstring_struct.cpp
+++ b/src/dbstring_struct.cpp
@@ -1,0 +1,211 @@
+/*
+ * This file is part of liblcf. Copyright (c) 2021 liblcf authors.
+ * https://github.com/EasyRPG/liblcf - https://easyrpg.org
+ *
+ * liblcf is Free/Libre Open Source Software, released under the MIT License.
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code.
+ */
+
+#include "lcf/dbstring.h"
+#include "reader_struct.h"
+#include <iostream>
+
+namespace lcf {
+
+/*
+DBString has the structure of a Pascal String (Length + Data).
+It could be a primitive type but vector<DBString> needs special handling.
+
+Vector<DBString> is Maniac Patch and is sparse:
+When size is > 0xFFFFFFFF there is a gap of "0x800000000 - size"
+In other cases it is as above: Size Data ... Size Data
+*/
+
+template <>
+struct RawStruct<DBString> {
+	static void ReadLcf(DBString& ref, LcfReader& stream, uint32_t length);
+	static void WriteLcf(const DBString& ref, LcfWriter& stream);
+	static int LcfSize(const DBString& ref, LcfWriter& stream);
+	static void WriteXml(const DBString& ref, XmlWriter& stream);
+	static void BeginXml(DBString& ref, XmlReader& stream);
+};
+
+template <>
+struct RawStruct<std::vector<DBString> > {
+	static void ReadLcf(std::vector<DBString>& ref, LcfReader& stream, uint32_t length);
+	static void WriteLcf(const std::vector<DBString>& ref, LcfWriter& stream);
+	static int LcfSize(const std::vector<DBString>& ref, LcfWriter& stream);
+	static void WriteXml(const std::vector<DBString>& ref, XmlWriter& stream);
+	static void BeginXml(std::vector<DBString>& ref, XmlReader& stream);
+};
+
+void RawStruct<DBString>::ReadLcf(DBString& ref, LcfReader& stream, uint32_t length) {
+	stream.ReadString(ref, length);
+#ifdef LCF_DEBUG_TRACE
+	printf("  %s\n", ref.c_str());
+#endif
+}
+
+void RawStruct<DBString>::WriteLcf(const DBString& ref, LcfWriter& stream) {
+	stream.Write(ref);
+}
+
+int RawStruct<DBString>::LcfSize(const DBString& ref, LcfWriter& stream) {
+	return stream.Decode(ref).size();
+}
+
+void RawStruct<DBString>::WriteXml(const DBString& ref, XmlWriter& stream) {
+	stream.Write(ref);
+}
+
+class DbStringXmlHandler : public XmlHandler {
+private:
+	DBString& ref;
+public:
+	DbStringXmlHandler(DBString& ref) :
+		ref(ref) {}
+	void StartElement(XmlReader& stream, const char* name, const char** /* atts */) {
+		// no-op
+	}
+	void EndElement(XmlReader& /* stream */, const char* /* name */) {
+		// no-op
+	}
+	void CharacterData(XmlReader& /* stream */, const std::string& data) {
+		ref = DBString(data);
+	}
+};
+
+void RawStruct<DBString>::BeginXml(DBString& /* ref */, XmlReader&  /* stream */) {
+	// no-op
+}
+
+void RawStruct<std::vector<DBString>>::ReadLcf(std::vector<DBString>& ref, LcfReader& stream, uint32_t length) {
+	int index = 0;
+	DBString string_var;
+
+	uint32_t startpos = stream.Tell();
+	uint32_t endpos = startpos + length;
+	while (stream.Tell() < endpos) {
+		// If size is bigger than 4 bytes, size indicates the gap size
+		// Otherwise it indicates the size of the next string
+		auto size = stream.ReadUInt64();
+		if (size > std::numeric_limits<uint32_t>::max()) {
+			index += static_cast<uint32_t>(0x800000000 - size);
+
+			ref.resize(index);
+		} else {
+			stream.ReadString(string_var, size);
+#ifdef LCF_DEBUG_TRACE
+			fprintf(stderr, "t[%d]: %s\n", index + 1, string_var.c_str());
+#endif
+			ref.push_back(string_var);
+
+			++index;
+		}
+	}
+
+	if (stream.Tell() != endpos) {
+#ifdef LCF_DEBUG_TRACE
+		fprintf(stderr, "Misaligned!\n");
+#endif
+		stream.Seek(endpos);
+	}
+}
+
+void RawStruct<std::vector<DBString>>::WriteLcf(const std::vector<DBString>& ref, LcfWriter& stream) {
+	int gap_size = 0;
+
+	for (size_t i = 0; i < ref.size(); ++i) {
+		const auto& e = ref[i];
+		if (e.empty()) {
+			++gap_size;
+			continue;
+		}
+
+		if (gap_size > 0) {
+			stream.WriteUInt64(0x800000000 - static_cast<uint64_t>(gap_size));
+			gap_size = 0;
+		}
+
+		auto len = RawStruct<DBString>::LcfSize(e, stream);
+		stream.WriteInt(len);
+		RawStruct<DBString>::WriteLcf(e, stream);
+	}
+}
+
+int RawStruct<std::vector<DBString>>::LcfSize(const std::vector<DBString>& ref, LcfWriter& stream) {
+	int result = 0;
+	int gap_size = 0;
+
+	for (size_t i = 0; i < ref.size(); ++i) {
+		const auto& e = ref[i];
+		if (e.empty()) {
+			++gap_size;
+			continue;
+		}
+
+		if (gap_size > 0) {
+			result += LcfReader::UInt64Size(0x800000000 - static_cast<uint64_t>(gap_size));
+			gap_size = 0;
+		}
+
+		int size = RawStruct<DBString>::LcfSize(e, stream);
+		result += LcfReader::IntSize(size);
+		result += size;
+	}
+
+	return result;
+}
+
+void RawStruct<std::vector<DBString>>::WriteXml(const std::vector<DBString>& ref, XmlWriter& stream) {
+	for (size_t i = 0; i < ref.size(); ++i) {
+		const auto& e = ref[i];
+		if (e.empty()) {
+			continue;
+		}
+
+		stream.BeginElement("item", i + 1);
+		RawStruct<DBString>::WriteXml(e, stream);
+		stream.EndElement("item");
+	}
+}
+
+class DbStringVectorXmlHandler : public XmlHandler {
+public:
+	DbStringVectorXmlHandler(std::vector<DBString>& ref) : ref(ref) {}
+
+	void StartElement(XmlReader& stream, const char* name, const char** atts) {
+		if (strcmp(name, "item") != 0) {
+			stream.Error("Expecting %s but got %s", "item", name);
+			return;
+		}
+
+		int last_id = -1;
+		int id = -1;
+		for (int i = 0; atts[i] != NULL && atts[i + 1] != NULL; i += 2) {
+			if (strcmp(atts[i], "id") == 0) {
+				id = atoi(atts[i + 1]);
+				break;
+			}
+		}
+
+		if (id <= last_id || id < -1) {
+			stream.Error("Bad Id %d / %d", id, last_id);
+			return;
+		}
+
+		ref.resize(id);
+		DBString& obj = ref.back();
+
+		stream.SetHandler(new DbStringXmlHandler(obj));
+	}
+private:
+	std::vector<DBString>& ref;
+};
+
+void RawStruct<std::vector<DBString>>::BeginXml(std::vector<DBString>& obj, XmlReader& stream) {
+	stream.SetHandler(new DbStringVectorXmlHandler(obj));
+}
+
+} //namspace lcf

--- a/src/generated/lcf/ldb/chunks.h
+++ b/src/generated/lcf/ldb/chunks.h
@@ -1512,7 +1512,7 @@ namespace LDB_Reader {
 			terms = 0x15,
 			/** rpg::System */
 			system = 0x16,
-			/** rpg::Switchs */
+			/** rpg::Switches */
 			switches = 0x17,
 			/** rpg::Variables */
 			variables = 0x18,

--- a/src/generated/lcf/lsd/chunks.h
+++ b/src/generated/lcf/lsd/chunks.h
@@ -162,6 +162,8 @@ namespace LSD_Reader {
 			save_slot = 0x84,
 			/** ATB mode of RPG 2003 battle system. */
 			atb_mode = 0x8C,
+			/** rpg::Strings */
+			maniac_strings = 0x24,
 			/** FatalMix Frameskip (0=None, 1=1/5, 2=1/3, 3=1/2) */
 			maniac_frameskip = 0x88,
 			/** FatalMix Picture Limit */

--- a/src/generated/lcf/rpg/savesystem.h
+++ b/src/generated/lcf/rpg/savesystem.h
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include "lcf/dbstring.h"
 #include "lcf/enum_tags.h"
 #include "lcf/rpg/music.h"
 #include "lcf/rpg/sound.h"
@@ -116,6 +117,7 @@ namespace rpg {
 		int32_t save_count = 0;
 		int32_t save_slot = 1;
 		int32_t atb_mode = 0;
+		std::vector<DBString> maniac_strings;
 		int32_t maniac_frameskip = 0;
 		int32_t maniac_picture_limit = 0;
 		std::vector<uint8_t> maniac_options;
@@ -186,6 +188,7 @@ namespace rpg {
 		&& l.save_count == r.save_count
 		&& l.save_slot == r.save_slot
 		&& l.atb_mode == r.atb_mode
+		&& l.maniac_strings == r.maniac_strings
 		&& l.maniac_frameskip == r.maniac_frameskip
 		&& l.maniac_picture_limit == r.maniac_picture_limit
 		&& l.maniac_options == r.maniac_options

--- a/src/generated/lsd_savesystem.cpp
+++ b/src/generated/lsd_savesystem.cpp
@@ -417,6 +417,13 @@ static TypedField<rpg::SaveSystem, int32_t> static_atb_mode(
 	0,
 	1
 );
+static TypedField<rpg::SaveSystem, std::vector<DBString>> static_maniac_strings(
+	&rpg::SaveSystem::maniac_strings,
+	LSD_Reader::ChunkSaveSystem::maniac_strings,
+	"maniac_strings",
+	0,
+	0
+);
 static TypedField<rpg::SaveSystem, int32_t> static_maniac_frameskip(
 	&rpg::SaveSystem::maniac_frameskip,
 	LSD_Reader::ChunkSaveSystem::maniac_frameskip,
@@ -506,6 +513,7 @@ Field<rpg::SaveSystem> const* Struct<rpg::SaveSystem>::fields[] = {
 	&static_save_count,
 	&static_save_slot,
 	&static_atb_mode,
+	&static_maniac_strings,
 	&static_maniac_frameskip,
 	&static_maniac_picture_limit,
 	&static_maniac_options,

--- a/src/generated/rpg_savesystem.cpp
+++ b/src/generated/rpg_savesystem.cpp
@@ -80,6 +80,11 @@ std::ostream& operator<<(std::ostream& os, const SaveSystem& obj) {
 	os << ", save_count="<< obj.save_count;
 	os << ", save_slot="<< obj.save_slot;
 	os << ", atb_mode="<< obj.atb_mode;
+	os << ", maniac_strings=";
+	for (size_t i = 0; i < obj.maniac_strings.size(); ++i) {
+		os << (i == 0 ? "[" : ", ") << obj.maniac_strings[i];
+	}
+	os << "]";
 	os << ", maniac_frameskip="<< obj.maniac_frameskip;
 	os << ", maniac_picture_limit="<< obj.maniac_picture_limit;
 	os << ", maniac_options=";

--- a/src/lcf/reader_lcf.h
+++ b/src/lcf/reader_lcf.h
@@ -130,6 +130,13 @@ public:
 	int ReadInt();
 
 	/**
+	 * Reads a compressed 64bit unsigned integer from the stream.
+	 *
+	 * @return The decompressed integer.
+	 */
+	uint64_t ReadUInt64();
+
+	/**
 	 * Reads a string.
 	 *
 	 * @param size string length.
@@ -203,6 +210,14 @@ public:
 	 * @return the compressed size.
 	 */
 	static int IntSize(unsigned int x);
+
+	/**
+	 * Calculates the size of a compressed 64bit unsigned integer
+	 *
+	 * @param x the integer.
+	 * @return the compressed size.
+	 */
+	static int UInt64Size(uint64_t x);
 
 	/** @return a buffer which can be reused for parsing */
 	std::vector<int32_t>& IntBuffer();

--- a/src/lcf/writer_lcf.h
+++ b/src/lcf/writer_lcf.h
@@ -83,6 +83,13 @@ public:
 	void WriteInt(int val);
 
 	/**
+	 * Write a compressed 64bit unsigned integer to the stream.
+	 *
+	 * @return The integer.
+	 */
+	void WriteUInt64(uint64_t val);
+
+	/**
 	 * Write a vector of primitive values to the stream.
 	 *
 	 * @param buffer vector to write.

--- a/src/reader_struct.h
+++ b/src/reader_struct.h
@@ -74,9 +74,10 @@ template <> struct TypeCategory<rpg::SaveEasyRpgWindow::Flags>	{ static const Ca
 template <> struct TypeCategory<rpg::Equipment>					{ static const Category::Index value = Category::RawStruct; };
 template <> struct TypeCategory<rpg::EventCommand>				{ static const Category::Index value = Category::RawStruct; };
 template <> struct TypeCategory<rpg::MoveCommand>				{ static const Category::Index value = Category::RawStruct; };
-template <> struct TypeCategory<rpg::Parameters>					{ static const Category::Index value = Category::RawStruct; };
+template <> struct TypeCategory<rpg::Parameters>				{ static const Category::Index value = Category::RawStruct; };
 template <> struct TypeCategory<rpg::TreeMap>					{ static const Category::Index value = Category::RawStruct; };
 template <> struct TypeCategory<rpg::Rect>						{ static const Category::Index value = Category::RawStruct; };
+template <>	struct TypeCategory<DBString>						{ static const Category::Index value = Category::RawStruct; };
 
 template <>	struct TypeCategory<int8_t> 						{ static const Category::Index value = Category::Primitive; };
 template <>	struct TypeCategory<uint8_t>						{ static const Category::Index value = Category::Primitive; };
@@ -86,7 +87,6 @@ template <>	struct TypeCategory<int32_t>						{ static const Category::Index val
 template <>	struct TypeCategory<bool>							{ static const Category::Index value = Category::Primitive; };
 template <>	struct TypeCategory<double>							{ static const Category::Index value = Category::Primitive; };
 template <>	struct TypeCategory<std::string>					{ static const Category::Index value = Category::Primitive; };
-template <>	struct TypeCategory<DBString>						{ static const Category::Index value = Category::Primitive; };
 template <>	struct TypeCategory<DBBitArray>						{ static const Category::Index value = Category::Primitive; };
 
 template <class T>
@@ -313,31 +313,6 @@ struct Primitive<std::string> {
 		stream.Write(ref);
 	}
 	static void ParseXml(std::string& ref, const std::string& data) {
-		XmlReader::Read(ref, data);
-	}
-};
-
-/**
- * DBString specialization.
- */
-template <>
-struct Primitive<DBString> {
-	static void ReadLcf(DBString& ref, LcfReader& stream, uint32_t length) {
-		stream.ReadString(ref, length);
-#ifdef LCF_DEBUG_TRACE
-		printf("  %s\n", ref.c_str());
-#endif
-	}
-	static void WriteLcf(const DBString& ref, LcfWriter& stream) {
-		stream.Write(ref);
-	}
-	static int LcfSize(const DBString& ref, LcfWriter& stream) {
-		return stream.Decode(ref).size();
-	}
-	static void WriteXml(const DBString& ref, XmlWriter& stream) {
-		stream.Write(ref);
-	}
-	static void ParseXml(DBString& ref, const std::string& data) {
 		XmlReader::Read(ref, data);
 	}
 };

--- a/src/reader_xml.cpp
+++ b/src/reader_xml.cpp
@@ -223,62 +223,62 @@ void XmlReader::ReadVector(DBArray<T>& val, const std::string& data) {
 
 template <>
 void XmlReader::Read<std::vector<int32_t>>(std::vector<int32_t>& val, const std::string& data) {
-       ReadVector<int32_t>(val, data);
+	ReadVector<int32_t>(val, data);
 }
 
 template <>
 void XmlReader::Read<std::vector<bool>>(std::vector<bool>& val, const std::string& data) {
-       ReadVector<bool>(val, data);
+	ReadVector<bool>(val, data);
 }
 
 template <>
 void XmlReader::Read<std::vector<uint8_t>>(std::vector<uint8_t>& val, const std::string& data) {
-       ReadVector<uint8_t>(val, data);
+	ReadVector<uint8_t>(val, data);
 }
 
 template <>
 void XmlReader::Read<std::vector<int16_t>>(std::vector<int16_t>& val, const std::string& data) {
-       ReadVector<int16_t>(val, data);
+	ReadVector<int16_t>(val, data);
 }
 
 template <>
 void XmlReader::Read<std::vector<uint32_t>>(std::vector<uint32_t>& val, const std::string& data) {
-       ReadVector<uint32_t>(val, data);
+	ReadVector<uint32_t>(val, data);
 }
 
 template <>
 void XmlReader::Read<std::vector<double>>(std::vector<double>& val, const std::string& data) {
-       ReadVector<double>(val, data);
+	ReadVector<double>(val, data);
 }
 
 template <>
 void XmlReader::Read<DBArray<int32_t>>(DBArray<int32_t>& val, const std::string& data) {
-       ReadVector<int32_t>(val, data);
+	ReadVector<int32_t>(val, data);
 }
 
 template <>
 void XmlReader::Read<DBArray<bool>>(DBArray<bool>& val, const std::string& data) {
-       ReadVector<bool>(val, data);
+	ReadVector<bool>(val, data);
 }
 
 template <>
 void XmlReader::Read<DBArray<uint8_t>>(DBArray<uint8_t>& val, const std::string& data) {
-       ReadVector<uint8_t>(val, data);
+	ReadVector<uint8_t>(val, data);
 }
 
 template <>
 void XmlReader::Read<DBArray<int16_t>>(DBArray<int16_t>& val, const std::string& data) {
-       ReadVector<int16_t>(val, data);
+	ReadVector<int16_t>(val, data);
 }
 
 template <>
 void XmlReader::Read<DBArray<uint32_t>>(DBArray<uint32_t>& val, const std::string& data) {
-       ReadVector<uint32_t>(val, data);
+	ReadVector<uint32_t>(val, data);
 }
 
 template <>
 void XmlReader::Read<DBArray<double>>(DBArray<double>& val, const std::string& data) {
-       ReadVector<double>(val, data);
+	ReadVector<double>(val, data);
 }
 
 

--- a/src/writer_lcf.cpp
+++ b/src/writer_lcf.cpp
@@ -54,6 +54,12 @@ void LcfWriter::WriteInt(int val) {
 			Write<uint8_t>((uint8_t)(((value >> i) & 0x7F) | (i > 0 ? 0x80 : 0)));
 }
 
+void LcfWriter::WriteUInt64(uint64_t value) {
+	for (int i = 56; i >= 0; i -= 7)
+		if (value >= (1LL << i) || i == 0)
+			Write<uint8_t>((uint8_t)(((value >> i) & 0x7F) | (i > 0 ? 0x80 : 0)));
+}
+
 template <>
 void LcfWriter::Write<int32_t>(int32_t val) {
 	WriteInt(val);


### PR DESCRIPTION
Maniac Patch uses this. Thanks to Jorge Pixel for figuring out how the array is structured.

Citing from the sourcecode

```
Vector<DBString> is Maniac Patch and is sparse:
When size is > 0xFFFFFFFF there is a gap of "0x800000000 - size"
In other cases it is as above: Size Data ... Size Data
```

---------

Note that this is only implemented for ``Vector<DBString>``, not ``Vector<std::string>``. During runtime the vector is not sprase, so every slot consumes memory. As most of the vector will be empty our ``DBString`` will be much more memory friendly.
