### PR TITLE
Lcf2xml: Use system encoding when no encoding is specified

### DIFF
--- a/tools/lcf2xml.cpp
+++ b/tools/lcf2xml.cpp
@@ -271,6 +271,9 @@ int ReaderWriteToFile(const std::string& in, const std::string& out, FileTypes i
 		std::cerr << "Failed opening directory " << path << std::endl;
 	}
 
+	if (encoding.empty()) {
+		encoding = lcf::ReaderUtil::GetLocaleEncoding();
+	}
 	dirsuccess:
 #endif
 


### PR DESCRIPTION
Makes UX a bit better as at least games in native system encoding will encode/decode correctly.

Also ``--encoding`` added for the CLI users.