### PR TITLE
Generator: Make int types available for References

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -199,7 +199,7 @@ def struct_headers(ty, header_map):
         return struct_headers(m.group(2), header_map)
 
     if re.match(r'Ref<(.*)>', ty):
-        return []
+        return ['<stdint.h>']
 
     if re.match(r'Enum<(.*)>', ty):
         return ['"lcf/enum_tags.h"']

--- a/src/generated/lcf/rpg/commonevent.h
+++ b/src/generated/lcf/rpg/commonevent.h
@@ -13,6 +13,7 @@
 #define LCF_RPG_COMMONEVENT_H
 
 // Headers
+#include <stdint.h>
 #include <vector>
 #include "lcf/dbstring.h"
 #include "lcf/enum_tags.h"

--- a/src/generated/lcf/rpg/encounter.h
+++ b/src/generated/lcf/rpg/encounter.h
@@ -11,6 +11,9 @@
 
 #ifndef LCF_RPG_ENCOUNTER_H
 #define LCF_RPG_ENCOUNTER_H
+
+// Headers
+#include <stdint.h>
 #include "lcf/context.h"
 #include <ostream>
 #include <type_traits>


### PR DESCRIPTION
Fixes the following build error (for Wii, g++ 13.1.0):

```
In file included from /var/lib/jenkins/workspace/liblcf-wii/src/generated/rpg_encounter.cpp:13:
/var/lib/jenkins/workspace/liblcf-wii/src/generated/lcf/rpg/encounter.h:26:17: error: 'int32_t' does not name a type
   26 |                 int32_t troop_id = 0;
      |                 ^~~~~~~
/var/lib/jenkins/workspace/liblcf-wii/src/generated/lcf/rpg/encounter.h:15:1: note: 'int32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   14 | #include "lcf/context.h"
  +++ |+#include <cstdint>
   15 | #include <ostream>
```