### PR TITLE
add lcf2xml python build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ build/
 # Python generated files
 *.pyc
 __pycache__/
+python/venv
 
 # other generated files
 Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ option(LIBLCF_WITH_ICU "ICU encoding detection (when OFF fallback to iconv, not 
 option(LIBLCF_WITH_XML "XML reading support (expat, default: ON)" ON)
 option(LIBLCF_UPDATE_MIMEDB "Whether to run update-mime-database after install (default: ON)" ON)
 option(LIBLCF_ENABLE_TOOLS "Whether to build the tools (default: ON)" ON)
-option(LIBLCF_ENABLE_TESTS "Whetner to build the unit tests (default: ON)" ON)
+option(LIBLCF_ENABLE_TESTS "Whether to build the unit tests (default: ON)" ON)
+option(LIBLCF_ENABLE_PYTHON "Whether to build the python library (default: ON)" ON)
 option(LIBLCF_ENABLE_BENCHMARKS "Whether to build the benchmarks (default: OFF)" OFF)
 
 set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Override CMAKE_DEBUG_POSTFIX.")
@@ -496,6 +497,16 @@ if(LIBLCF_ENABLE_TOOLS)
 		add_dependencies(tools ${tool})
 		install(TARGETS ${tool} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endforeach()
+endif()
+
+# python
+if (LIBLCF_ENABLE_PYTHON)
+	execute_process(COMMAND python -m venv ${CMAKE_CURRENT_BINARY_DIR}/python/venv)
+	execute_process(COMMAND ${CMAKE_CURRENT_BINARY_DIR}/python/venv/bin/python -m pip install pybind11)
+	FILE(GLOB pybind11_DIR ${CMAKE_CURRENT_BINARY_DIR}/python/venv/lib/python*/site-packages/pybind11/share/cmake/pybind11)
+	find_package(pybind11 CONFIG REQUIRED)
+	pybind11_add_module(pylcf2xml python/pylcf2xml.cpp)
+	target_link_libraries(pylcf2xml PUBLIC lcf)
 endif()
 
 # Doxygen documentation

--- a/python/pylcf2xml.cpp
+++ b/python/pylcf2xml.cpp
@@ -1,0 +1,95 @@
+#include "pylcf2xml.h"
+#include <pybind11/pybind11.h>
+
+lcf::EngineVersion GetEngineVersion(std::string engine) {
+    if (engine == "2k3") {
+        return lcf::EngineVersion::e2k3;
+    }
+    return lcf::EngineVersion::e2k;
+}
+
+std::string lmu2xml(const std::string& in, std::string engine, std::string encoding) {
+    std::istringstream istream(in, std::ios::binary);
+    auto file = lcf::LMU_Reader::Load(istream, encoding);
+    std::ostringstream ostream(std::ios::binary);
+    lcf::LMU_Reader::SaveXml(ostream, *file, GetEngineVersion(engine));
+    return ostream.str();
+}
+
+std::string lsd2xml(const std::string& in, std::string engine, std::string encoding) {
+    std::istringstream istream(in, std::ios::binary);
+    auto file = lcf::LSD_Reader::Load(istream, encoding);
+    std::ostringstream ostream(std::ios::binary);
+    lcf::LSD_Reader::SaveXml(ostream, *file, GetEngineVersion(engine));
+    return ostream.str();
+}
+
+std::string ldb2xml(const std::string& in, std::string encoding) {
+    std::istringstream istream(in, std::ios::binary);
+    auto file = lcf::LDB_Reader::Load(istream, encoding);
+    std::ostringstream ostream(std::ios::binary);
+    lcf::LDB_Reader::SaveXml(ostream, *file);
+    return ostream.str();
+}
+
+std::string lmt2xml(const std::string& in, std::string engine, std::string encoding) {
+    std::istringstream istream(in, std::ios::binary);
+    auto file = lcf::LMT_Reader::Load(istream, encoding);
+    std::ostringstream ostream(std::ios::binary);
+    lcf::LMT_Reader::SaveXml(ostream, *file, GetEngineVersion(engine));
+    return ostream.str();
+}
+
+std::string xml2lmu(const std::string& in, std::string engine, std::string encoding) {
+    std::istringstream istream(in, std::ios::binary);
+    auto file = lcf::LMU_Reader::LoadXml(istream);
+    std::ostringstream ostream(std::ios::binary);
+    lcf::LMU_Reader::Save(ostream, *file, GetEngineVersion(engine), encoding);
+    return ostream.str();
+}
+
+std::string xml2lsd(const std::string& in, std::string engine, std::string encoding) {
+    std::istringstream istream(in, std::ios::binary);
+    auto file = lcf::LSD_Reader::LoadXml(istream);
+    std::ostringstream ostream(std::ios::binary);
+    lcf::LSD_Reader::Save(ostream, *file, GetEngineVersion(engine), encoding);
+    return ostream.str();
+}
+
+std::string xml2ldb(const std::string& in, std::string encoding) {
+    std::istringstream istream(in, std::ios::binary);
+    auto file = lcf::LDB_Reader::LoadXml(istream);
+    std::ostringstream ostream(std::ios::binary);
+    lcf::LDB_Reader::Save(ostream, *file, encoding);
+    return ostream.str();
+}
+
+std::string xml2lmt(const std::string& in, std::string engine, std::string encoding) {
+    std::istringstream istream(in, std::ios::binary);
+    auto file = lcf::LMT_Reader::LoadXml(istream);
+    std::ostringstream ostream(std::ios::binary);
+    lcf::LMT_Reader::Save(ostream, *file, GetEngineVersion(engine), encoding);
+    return ostream.str();
+}
+
+PYBIND11_MODULE(pylcf2xml, m) {
+    m.doc() =
+        "LCF2XML is a small tool to convert RPG Maker 2000 and 2003 data format (LMU, LMT, LDB, LSD, ...) to XML and "
+        "vice versa.";
+    m.def("lmu2xml", &lmu2xml, "Convert .lmu file into xml", pybind11::arg("in"), pybind11::kw_only(),
+          pybind11::arg("engine") = "2k3", pybind11::arg("encoding"));
+    m.def("lsd2xml", &lsd2xml, "Convert .lsd file into xml", pybind11::arg("in"), pybind11::kw_only(),
+          pybind11::arg("engine") = "2k3", pybind11::arg("encoding"));
+    m.def("ldb2xml", &ldb2xml, "Convert .ldb file into xml", pybind11::arg("in"), pybind11::kw_only(),
+          pybind11::arg("encoding"));
+    m.def("lmt2xml", &lmt2xml, "Convert .lmt file into xml", pybind11::arg("in"), pybind11::kw_only(),
+          pybind11::arg("engine") = "2k3", pybind11::arg("encoding"));
+    m.def("xml2lmu", &xml2lmu, "Convert xml file into .lmu", pybind11::arg("in"), pybind11::kw_only(),
+          pybind11::arg("engine") = "2k3", pybind11::arg("encoding"));
+    m.def("xml2lsd", &xml2lsd, "Convert xml file into .lsd", pybind11::arg("in"), pybind11::kw_only(),
+          pybind11::arg("engine") = "2k3", pybind11::arg("encoding"));
+    m.def("xml2ldb", &xml2ldb, "Convert xml file into .ldb", pybind11::arg("in"), pybind11::kw_only(),
+          pybind11::arg("encoding"));
+    m.def("xml2lmt", &xml2lmt, "Convert xml file into .lmt", pybind11::arg("in"), pybind11::kw_only(),
+          pybind11::arg("engine") = "2k3", pybind11::arg("encoding"));
+}

--- a/python/pylcf2xml.h
+++ b/python/pylcf2xml.h
@@ -1,0 +1,23 @@
+#include <lcf/ldb/reader.h>
+#include <lcf/lmt/reader.h>
+#include <lcf/lmu/reader.h>
+#include <lcf/lsd/reader.h>
+#include <lcf/reader_lcf.h>
+#include <lcf/reader_util.h>
+#include <sstream>
+
+std::string lmu2xml(const std::string& in, std::string engine, std::string encoding);
+
+std::string lsd2xml(const std::string& in, std::string engine, std::string encoding);
+
+std::string ldb2xml(const std::string& in, std::string encoding);
+
+std::string lmt2xml(const std::string& in, std::string engine, std::string encoding);
+
+std::string xml2lmu(const std::string& in, std::string engine, std::string encoding);
+
+std::string xml2lsd(const std::string& in, std::string engine, std::string encoding);
+
+std::string xml2ldb(const std::string& in, std::string encoding);
+
+std::string xml2lmt(const std::string& in, std::string engine, std::string encoding);


### PR DESCRIPTION
Hello

I've made some modifications to enable the use of this library in Python. The build process remains unchanged, and only need to have Python installed.

I've wanted to use this library in a Firebase Python server environment, where file I/O is restricted. I think this may some helpful for someone.

```python
import pylcf2xml
ldb = open('RPG_RT.ldb', 'rb').read()
xml = pylcf2xml.ldb2xml(ldb, encoding='949')
print(xml)
```