### PR TITLE
Fix heap corruption in Encoder

### DIFF
--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -7,7 +7,6 @@
  * file that was distributed with this source code.
  */
 
-#include "lcf/config.h"
 #include "lcf/encoder.h"
 #include "lcf/reader_util.h"
 #include "lcf/scope_guard.h"

--- a/src/lcf/encoder.h
+++ b/src/lcf/encoder.h
@@ -9,6 +9,8 @@
 
 #ifndef LCF_ENCODER_H
 #define LCF_ENCODER_H
+
+#include "lcf/config.h"
 #include <vector>
 #include <string>
 


### PR DESCRIPTION
The defines were not correctly handled because config.h was not included

This crashed on macOS and thankfully also on 32 bit Windows where the debugger is better ;)