### PR TITLE
Code generation fix: Specifying new values for existing enums in a separate file might overwrite existing ones

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -312,7 +312,12 @@ def get_enums(*filenames):
     for k, v in merge_dicts(results).items():
         new_result[k] = OrderedDict()
         for kk, gg in groupby(v, operator.attrgetter("entry")):
-            new_result[k][kk] = list(map(lambda x: (x.value, x.index), gg))
+            list_of = list(map(lambda x: (x.value, x.index), gg))
+            if kk in new_result[k]:
+                for elem in list_of:
+                    new_result[k][kk].append(elem)
+            else:
+                new_result[k][kk] = list_of
 
     return new_result
 


### PR DESCRIPTION
Easily reproducible by introducing new values in easyrpg_fields.csv:

```
EventPage,Trigger,map_init_deferred,8
EventPage,Trigger,map_init_immediate,9
```

Depends on order though. I defined these values at line 35, right before the Maniac stuff:
`EventPage,ManiacEventInfo,*`