### PR TITLE
Maniac Patch : Adding separate camera pan speeds from Maniac Patch

### DIFF
--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -31,6 +31,8 @@ SaveEasyRpgText,letter_spacing,f,Int32,0x06,0,0,0,Additional spacing between let
 SaveEasyRpgText,line_spacing,f,Int32,0x07,4,0,0,Additional spacing between lines
 SaveEasyRpgText,flags,f,SaveEasyRpgText_Flags,0x08,3,0,0,Various text settings
 SaveMapEventBase,easyrpg_move_failure_count,f,Int32,0xC9,0,0,0,Tracks how often the current move operation in a move route failed
+SavePartyLocation,maniac_horizontal_pan_speed,f,Double,0x8D,0,0,0,horizontal speed in the scrolls of the screen
+SavePartyLocation,maniac_vertical_pan_speed,f,Double,0x8E,0,0,0,vertical speed in the scrolls of the screen
 SaveSystem,maniac_strings,f,Vector<DBString>,0x24,,0,0,rpg::Strings
 SaveSystem,maniac_frameskip,,Int32,0x88,0,0,0,"FatalMix Frameskip (0=None, 1=1/5, 2=1/3, 3=1/2)"
 SaveSystem,maniac_picture_limit,,Int32,0x89,0,0,0,FatalMix Picture Limit

--- a/src/generated/lcf/lsd/chunks.h
+++ b/src/generated/lcf/lsd/chunks.h
@@ -441,7 +441,11 @@ namespace LSD_Reader {
 			/** Mirrors save_count of current map. On mismatch events are not continued after load. */
 			map_save_count = 0x83,
 			/** ? */
-			database_save_count = 0x84
+			database_save_count = 0x84,
+			/** horizontal speed in the scrolls of the screen. */
+			maniac_horizontal_pan_speed = 0x8D,
+			/** vertical speed in the scrolls of the screen. */
+			maniac_vertical_pan_speed = 0x8E
 		};
 	};
 	struct ChunkSaveVehicleLocation {

--- a/src/generated/lcf/rpg/savepartylocation.h
+++ b/src/generated/lcf/rpg/savepartylocation.h
@@ -71,6 +71,8 @@ namespace rpg {
 		bool encounter_calling = false;
 		int32_t map_save_count = 0;
 		int32_t database_save_count = 0;
+		double maniac_horizontal_pan_speed = 0.0;
+		double maniac_vertical_pan_speed = 0.0;
 	};
 	inline std::ostream& operator<<(std::ostream& os, SavePartyLocation::VehicleType code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -97,7 +99,9 @@ namespace rpg {
 		&& l.total_encounter_rate == r.total_encounter_rate
 		&& l.encounter_calling == r.encounter_calling
 		&& l.map_save_count == r.map_save_count
-		&& l.database_save_count == r.database_save_count;
+		&& l.database_save_count == r.database_save_count
+		&& l.maniac_horizontal_pan_speed == r.maniac_horizontal_pan_speed
+		&& l.maniac_vertical_pan_speed == r.maniac_vertical_pan_speed;
 	}
 
 	inline bool operator!=(const SavePartyLocation& l, const SavePartyLocation& r) {

--- a/src/generated/lsd_savepartylocation.cpp
+++ b/src/generated/lsd_savepartylocation.cpp
@@ -412,6 +412,20 @@ static TypedField<rpg::SavePartyLocation, int32_t> static_database_save_count(
 	0,
 	0
 );
+static TypedField<rpg::SavePartyLocation, double> static_maniac_horizontal_pan_speed(
+	&rpg::SavePartyLocation::maniac_horizontal_pan_speed,
+	LSD_Reader::ChunkSavePartyLocation::maniac_horizontal_pan_speed,
+	"maniac_horizontal_pan_speed",
+	0,
+	0
+);
+static TypedField<rpg::SavePartyLocation, double> static_maniac_vertical_pan_speed(
+	&rpg::SavePartyLocation::maniac_vertical_pan_speed,
+	LSD_Reader::ChunkSavePartyLocation::maniac_vertical_pan_speed,
+	"maniac_vertical_pan_speed",
+	0,
+	0
+);
 
 
 template <>
@@ -472,6 +486,8 @@ Field<rpg::SavePartyLocation> const* Struct<rpg::SavePartyLocation>::fields[] = 
 	&static_encounter_calling,
 	&static_map_save_count,
 	&static_database_save_count,
+	&static_maniac_horizontal_pan_speed,
+	&static_maniac_vertical_pan_speed,
 	NULL
 };
 

--- a/src/generated/rpg_savepartylocation.cpp
+++ b/src/generated/rpg_savepartylocation.cpp
@@ -36,6 +36,8 @@ std::ostream& operator<<(std::ostream& os, const SavePartyLocation& obj) {
 	os << ", encounter_calling="<< obj.encounter_calling;
 	os << ", map_save_count="<< obj.map_save_count;
 	os << ", database_save_count="<< obj.database_save_count;
+	os << ", maniac_horizontal_pan_speed="<< obj.maniac_horizontal_pan_speed;
+	os << ", maniac_vertical_pan_speed="<< obj.maniac_vertical_pan_speed;
 	os << "}";
 	return os;
 }


### PR DESCRIPTION
Maniac Patch has a was for scrolling screen with pixel precision.

It uses two doubles, stored inside SavePartyLocation at 0x8D and 0x8E respectively.

Sister request for https://github.com/EasyRPG/Player/pull/3245