### PR TITLE
Restore Bit perfect read/write ability

### DIFF
--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -14,8 +14,8 @@ SaveEventExecState,easyrpg_parameters,f,Vector<Int32>,0xCB,,0,0,Preserved int pa
 SavePicture,easyrpg_flip,f,Enum<EasyRpgFlip>,0xC8,0,0,1,How to flip the picture
 SavePicture,easyrpg_blend_mode,f,Int32,0xC9,0,0,1,Blend mode to use for blit. See Bitmap::BlendMode
 SavePicture,easyrpg_type,f,Enum<EasyRpgPictureType>,0xCA,0,0,1,Type of this picture
-SavePicture,maniac_current_magnify_height,f,Double,0x0A,100.0,0,1,Current zoom level of picture (y direction).
-SavePicture,maniac_finish_magnify_height,f,Int32,0x24,100,0,1,Final zoom level to animate picture to (y direction).
+SavePicture,maniac_current_magnify_height,f,Double,0x0A,100.0,0,0,Current zoom level of picture (y direction).
+SavePicture,maniac_finish_magnify_height,f,Int32,0x24,100,0,0,Final zoom level to animate picture to (y direction).
 SaveEasyRpgWindow,texts,f,Array<SaveEasyRpgText>,0x01,,0,0,Texts to render
 SaveEasyRpgWindow,width,f,Int32,0x02,0,0,0,Window width (px)
 SaveEasyRpgWindow,height,f,Int32,0x03,0,0,0,Window height (px)

--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -51,10 +51,10 @@ Actor,easyrpg_immune_to_attribute_downshifts,f,Boolean,0xCC,False,0,0,If the act
 Actor,easyrpg_ignore_evasion,f,Boolean,0xCD,False,0,0,If the actors unarmed physical attacks ignore evasion
 Actor,easyrpg_unarmed_hit,f,Int32,0xCE,-1,0,0,Hit rate of the actor on unarmed attacks
 Actor,easyrpg_unarmed_state_set,t,DBBitArray,0xCF,,0,0,States inflicted by unarmed normal attacks of the actor
-Actor,easyrpg_unarmed_state_set,f,DBBitArray,0xD0,,1,0,States inflicted by unarmed normal attacks of the actor
+Actor,easyrpg_unarmed_state_set,f,DBBitArray,0xD0,,0,0,States inflicted by unarmed normal attacks of the actor
 Actor,easyrpg_unarmed_state_chance,f,Int32,0xD1,0,0,0,State infliction probability by unarmed normal attacks of the actor
 Actor,easyrpg_unarmed_attribute_set,t,DBBitArray,0xD2,,0,0,Attributes used by unarmed normal attacks of the actor
-Actor,easyrpg_unarmed_attribute_set,f,DBBitArray,0xD3,,1,0,Attributes used by unarmed normal attacks of the actor
+Actor,easyrpg_unarmed_attribute_set,f,DBBitArray,0xD3,,0,0,Attributes used by unarmed normal attacks of the actor
 Actor,easyrpg_dual_attack,f,Boolean,0xD4,False,0,0,If the actors unarmed physical attacks hits twice
 Actor,easyrpg_attack_all,f,Boolean,0xD5,False,0,0,If the actors unarmed physical targets the entire enemy party
 Enemy,maniac_unarmed_animation,f,Ref<Animation>,0x0F,1,0,0,Animation for normal enemy attacks (Maniac Patch only)
@@ -65,10 +65,10 @@ Enemy,easyrpg_immune_to_attribute_downshifts,f,Boolean,0xCC,False,0,0,If the ene
 Enemy,easyrpg_ignore_evasion,f,Boolean,0xCD,False,0,0,If the enemies unarmed physical attacks ignore evasion
 Enemy,easyrpg_hit,f,Int32,0xCE,-1,0,0,Hit rate of the enemy on normal attacks
 Enemy,easyrpg_state_set,t,DBBitArray,0xCF,,0,0,States inflicted by normal attacks of the enemy
-Enemy,easyrpg_state_set,f,DBBitArray,0xD0,,1,0,States inflicted by normal attacks of the enemy
+Enemy,easyrpg_state_set,f,DBBitArray,0xD0,,0,0,States inflicted by normal attacks of the enemy
 Enemy,easyrpg_state_chance,f,Int32,0xD1,0,0,0,State infliction probability by normal attacks of the enemy
 Enemy,easyrpg_attribute_set,t,DBBitArray,0xD2,,0,0,Attributes used by normal attacks of the enemy
-Enemy,easyrpg_attribute_set,f,DBBitArray,0xD3,,1,0,Attributes used by normal attacks of the enemy
+Enemy,easyrpg_attribute_set,f,DBBitArray,0xD3,,0,0,Attributes used by normal attacks of the enemy
 Enemy,easyrpg_super_guard,f,Boolean,0xD4,False,0,0,If the enemies defend action quarters instead of halves HP damage
 Enemy,easyrpg_attack_all,f,Boolean,0xD5,False,0,0,If the enemies unarmed physical targets the entire player party
 Skill,easyrpg_battle2k3_message,f,DBString,0xC9,DBString(kDefaultMessage),0,1,RPG Maker 2003 battle skill start notification
@@ -87,7 +87,7 @@ Skill,easyrpg_hp_cost,f,Int32,0xD5,0,0,0,How much HP does the usage of the skill
 Item,easyrpg_using_message,f,DBString,0xC9,DBString(kDefaultMessage),0,0,Item usage message in battle
 Item,easyrpg_max_count,f,Int32,0xCA,-1,0,0,How many the player can carry of this item
 State,easyrpg_immune_states,t,DBBitArray,0xC8,,0,0,States cleared on infliction by this state
-State,easyrpg_immune_states,f,DBBitArray,0xC9,,1,0,States cleared on infliction by this state
+State,easyrpg_immune_states,f,DBBitArray,0xC9,,0,0,States cleared on infliction by this state
 Terrain,easyrpg_damage_in_percent,f,Boolean,0xC8,False,0,0,If the terrain damage is a percentage
 Terrain,easyrpg_damage_can_kill,f,Boolean,0xC9,False,0,0,If the terrain damage can kill the actors
 Terms,easyrpg_item_number_separator,f,DBString,0xC8,DBString(kDefaultTerm),0,0,Item number separator

--- a/src/generated/lcf/lsd/chunks.h
+++ b/src/generated/lcf/lsd/chunks.h
@@ -442,9 +442,9 @@ namespace LSD_Reader {
 			map_save_count = 0x83,
 			/** ? */
 			database_save_count = 0x84,
-			/** horizontal speed in the scrolls of the screen. */
+			/** horizontal speed in the scrolls of the screen */
 			maniac_horizontal_pan_speed = 0x8D,
-			/** vertical speed in the scrolls of the screen. */
+			/** vertical speed in the scrolls of the screen */
 			maniac_vertical_pan_speed = 0x8E
 		};
 	};

--- a/src/generated/ldb_actor.cpp
+++ b/src/generated/ldb_actor.cpp
@@ -301,7 +301,7 @@ static TypedField<rpg::Actor, DBBitArray> static_easyrpg_unarmed_state_set(
 	&rpg::Actor::easyrpg_unarmed_state_set,
 	LDB_Reader::ChunkActor::easyrpg_unarmed_state_set,
 	"easyrpg_unarmed_state_set",
-	1,
+	0,
 	0
 );
 static TypedField<rpg::Actor, int32_t> static_easyrpg_unarmed_state_chance(
@@ -321,7 +321,7 @@ static TypedField<rpg::Actor, DBBitArray> static_easyrpg_unarmed_attribute_set(
 	&rpg::Actor::easyrpg_unarmed_attribute_set,
 	LDB_Reader::ChunkActor::easyrpg_unarmed_attribute_set,
 	"easyrpg_unarmed_attribute_set",
-	1,
+	0,
 	0
 );
 static TypedField<rpg::Actor, bool> static_easyrpg_dual_attack(

--- a/src/generated/ldb_enemy.cpp
+++ b/src/generated/ldb_enemy.cpp
@@ -238,7 +238,7 @@ static TypedField<rpg::Enemy, DBBitArray> static_easyrpg_state_set(
 	&rpg::Enemy::easyrpg_state_set,
 	LDB_Reader::ChunkEnemy::easyrpg_state_set,
 	"easyrpg_state_set",
-	1,
+	0,
 	0
 );
 static TypedField<rpg::Enemy, int32_t> static_easyrpg_state_chance(
@@ -258,7 +258,7 @@ static TypedField<rpg::Enemy, DBBitArray> static_easyrpg_attribute_set(
 	&rpg::Enemy::easyrpg_attribute_set,
 	LDB_Reader::ChunkEnemy::easyrpg_attribute_set,
 	"easyrpg_attribute_set",
-	1,
+	0,
 	0
 );
 static TypedField<rpg::Enemy, bool> static_easyrpg_super_guard(

--- a/src/generated/ldb_state.cpp
+++ b/src/generated/ldb_state.cpp
@@ -324,7 +324,7 @@ static TypedField<rpg::State, DBBitArray> static_easyrpg_immune_states(
 	&rpg::State::easyrpg_immune_states,
 	LDB_Reader::ChunkState::easyrpg_immune_states,
 	"easyrpg_immune_states",
-	1,
+	0,
 	0
 );
 

--- a/src/generated/lsd_savepicture.cpp
+++ b/src/generated/lsd_savepicture.cpp
@@ -312,14 +312,14 @@ static TypedField<rpg::SavePicture, double> static_maniac_current_magnify_height
 	LSD_Reader::ChunkSavePicture::maniac_current_magnify_height,
 	"maniac_current_magnify_height",
 	0,
-	1
+	0
 );
 static TypedField<rpg::SavePicture, int32_t> static_maniac_finish_magnify_height(
 	&rpg::SavePicture::maniac_finish_magnify_height,
 	LSD_Reader::ChunkSavePicture::maniac_finish_magnify_height,
 	"maniac_finish_magnify_height",
 	0,
-	1
+	0
 );
 
 


### PR DESCRIPTION
For #484 I removed the dust from my old diff tool used in #242 and noticed that the files differ after a load-save-operation with liblcf.

A few of our custom chunks were set to _PersistIfDefault_ (always write, even when default value), so they were added to all database files processed by liblcf (e.g. lcf2xml).

This didn't damage the files but was a useless addition which increased the filesize.

Now the files are perfect again :) (= a read-write-cycle changes nothing in the files)
