### PR TITLE
Support ICU library provided by Windows 10 + Preset updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,10 +348,23 @@ target_link_libraries(lcf inih::inih)
 # icu
 set(LCF_SUPPORT_ICU 0)
 if(LIBLCF_WITH_ICU)
-	find_package(ICU COMPONENTS i18n uc data REQUIRED)
-	target_link_libraries(lcf ICU::i18n ICU::uc ICU::data)
-	list(APPEND LIBLCF_DEPS "icu-i18n")
-	set(LCF_SUPPORT_ICU 1)
+	find_package(ICU COMPONENTS i18n uc data)
+	if(ICU_FOUND)
+		target_link_libraries(lcf ICU::i18n ICU::uc ICU::data)
+		list(APPEND LIBLCF_DEPS "icu-i18n")
+		set(LCF_SUPPORT_ICU 1)
+	else()
+		if(NOT WIN32)
+			message(FATAL_ERROR "ICU not found. Use LCF_SUPPORT_ICU=0 to disable ICU support (not recommended).")
+		endif()
+
+		message(STATUS "ICU not found. Using the system library.")
+		message(STATUS "This build will only work on Windows 10 Version 1903 (May 2019) and newer!")
+
+		target_link_libraries(lcf icu)
+		set(LCF_SUPPORT_ICU 2)
+		list(APPEND LIBLCF_DEPS "icu")
+	endif()
 endif()
 
 # expat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ option(LIBLCF_ENABLE_BENCHMARKS "Whether to build the benchmarks (default: OFF)"
 option(LIBLCF_ENABLE_INSTALL "Whether to add an install target (default: ON)" ${LIBLCF_MAIN_PROJECT})
 set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Override CMAKE_DEBUG_POSTFIX.")
 
+# Dependencies provided by CMake Presets
+list(APPEND CMAKE_PREFIX_PATH "${LIBLCF_PREFIX_PATH_APPEND}")
+
 # C++17 is required
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -49,7 +49,7 @@
 			"name": "linux-parent",
 			"toolchainFile": "${sourceDir}/builds/cmake/LinuxToolchain.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/linux-static"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/linux-static"
 			},
 			"hidden": true,
 			"inherits": "base-user"
@@ -79,34 +79,34 @@
 			]
 		},
 		{
-			"name": "windows-x86-parent",
+			"name": "windows-parent",
 			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x86-windows-static"
+				"VCPKG_TARGET_TRIPLET": "$env{VSCMD_ARG_TGT_ARCH}-windows-static"
 			},
 			"inherits": "win-user",
 			"hidden": true
 		},
 		{
-			"name": "windows-x86-debug",
-			"displayName": "Windows (x86) (Debug)",
+			"name": "windows-debug",
+			"displayName": "Windows (Debug)",
 			"inherits": [
-				"windows-x86-parent",
+				"windows-parent",
 				"type-debug"
 			]
 		},
 		{
-			"name": "windows-x86-relwithdebinfo",
-			"displayName": "Windows (x86) (RelWithDebInfo)",
+			"name": "windows-relwithdebinfo",
+			"displayName": "Windows (RelWithDebInfo)",
 			"inherits": [
-				"windows-x86-parent",
+				"windows-parent",
 				"type-relwithdebinfo"
 			]
 		},
 		{
-			"name": "windows-x86-release",
-			"displayName": "Windows (x86) (Release)",
+			"name": "windows-release",
+			"displayName": "Windows (Release)",
 			"inherits": [
-				"windows-x86-parent",
+				"windows-parent",
 				"type-release"
 			]
 		},
@@ -141,39 +141,6 @@
 			"displayName": "Windows (x86) using Visual Studio 2022 (Release)",
 			"inherits": [
 				"windows-x86-vs2022-parent",
-				"type-release"
-			]
-		},
-		{
-			"name": "windows-x64-parent",
-			"architecture": "x64",
-			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x64-windows-static"
-			},
-			"inherits": "win-user",
-			"hidden": true
-		},
-		{
-			"name": "windows-x64-debug",
-			"displayName": "Windows (x64) (Debug)",
-			"inherits": [
-				"windows-x64-parent",
-				"type-debug"
-			]
-		},
-		{
-			"name": "windows-x64-relwithdebinfo",
-			"displayName": "Windows (x64) (RelWithDebInfo)",
-			"inherits": [
-				"windows-x64-parent",
-				"type-relwithdebinfo"
-			]
-		},
-		{
-			"name": "windows-x64-release",
-			"displayName": "Windows (x64) (Release)",
-			"inherits": [
-				"windows-x64-parent",
 				"type-release"
 			]
 		},
@@ -214,7 +181,7 @@
 		{
 			"name": "macos-parent",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/osx",
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/osx",
 				"CMAKE_OSX_DEPLOYMENT_TARGET": "10.9"
 			},
 			"condition": {
@@ -254,7 +221,7 @@
 			"toolchainFile": "$env{EASYRPG_BUILDSCRIPTS}/emscripten/emsdk-portable/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
 			"cacheVariables": {
 				"LIBLCF_ENABLE_TOOLS": "OFF",
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
 				"CMAKE_FIND_ROOT_PATH": "$env{EASYRPG_BUILDSCRIPTS}/emscripten"
 			},
 			"hidden": true,
@@ -288,7 +255,8 @@
 			"name": "3ds-parent",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/3DS.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/3ds"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/3ds",
+				"LIBLCF_ENABLE_TOOLS": "OFF"
 			},
 			"inherits": "dkp-user",
 			"hidden": true
@@ -321,7 +289,8 @@
 			"name": "switch-parent",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Switch.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/switch"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/switch",
+				"LIBLCF_ENABLE_TOOLS": "OFF"
 			},
 			"inherits": "dkp-user",
 			"hidden": true
@@ -354,7 +323,8 @@
 			"name": "wii-parent",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Wii.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/wii"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wii",
+				"LIBLCF_ENABLE_TOOLS": "OFF"
 			},
 			"inherits": "dkp-user",
 			"hidden": true
@@ -380,6 +350,40 @@
 			"displayName": "Nintendo Wii (Release)",
 			"inherits": [
 				"wii-parent",
+				"type-release"
+			]
+		},
+		{
+			"name": "wiiu-parent",
+			"toolchainFile": "$env{DEVKITPRO}/cmake/WiiU.cmake",
+			"cacheVariables": {
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wiiu",
+				"LIBLCF_ENABLE_TOOLS": "OFF"
+			},
+			"inherits": "dkp-user",
+			"hidden": true
+		},
+		{
+			"name": "wiiu-debug",
+			"displayName": "Nintendo WiiU (Debug)",
+			"inherits": [
+				"wiiu-parent",
+				"type-debug"
+			]
+		},
+		{
+			"name": "wiiu-relwithdebinfo",
+			"displayName": "Nintendo WiiU (RelWithDebInfo)",
+			"inherits": [
+				"wiiu-parent",
+				"type-relwithdebinfo"
+			]
+		},
+		{
+			"name": "wiiu-release",
+			"displayName": "Nintendo WiiU (Release)",
+			"inherits": [
+				"wiiu-parent",
 				"type-release"
 			]
 		},
@@ -575,16 +579,16 @@
 			"configurePreset": "linux-release"
 		},
 		{
-			"name": "windows-x86-debug",
-			"configurePreset": "windows-x86-debug"
+			"name": "windows-debug",
+			"configurePreset": "windows-debug"
 		},
 		{
-			"name": "windows-x86-relwithdebinfo",
-			"configurePreset": "windows-x86-relwithdebinfo"
+			"name": "windows-relwithdebinfo",
+			"configurePreset": "windows-relwithdebinfo"
 		},
 		{
-			"name": "windows-x86-release",
-			"configurePreset": "windows-x86-release"
+			"name": "windows-release",
+			"configurePreset": "windows-release"
 		},
 		{
 			"name": "windows-x86-vs2022-debug",
@@ -597,18 +601,6 @@
 		{
 			"name": "windows-x86-vs2022-release",
 			"configurePreset": "windows-x86-vs2022-release"
-		},
-		{
-			"name": "windows-x64-debug",
-			"configurePreset": "windows-x64-debug"
-		},
-		{
-			"name": "windows-x64-relwithdebinfo",
-			"configurePreset": "windows-x64-relwithdebinfo"
-		},
-		{
-			"name": "windows-x64-release",
-			"configurePreset": "windows-x64-release"
 		},
 		{
 			"name": "windows-x64-vs2022-debug",
@@ -681,6 +673,18 @@
 		{
 			"name": "wii-release",
 			"configurePreset": "wii-release"
+		},
+		{
+			"name": "wiiu-debug",
+			"configurePreset": "wiiu-debug"
+		},
+		{
+			"name": "wiiu-relwithdebinfo",
+			"configurePreset": "wiiu-relwithdebinfo"
+		},
+		{
+			"name": "wiiu-release",
+			"configurePreset": "wiiu-release"
 		},
 		{
 			"name": "psvita-debug",

--- a/builds/cmake/CMakePresets.json.template
+++ b/builds/cmake/CMakePresets.json.template
@@ -18,7 +18,7 @@
 			"displayName": "Linux",
 			"toolchainFile": "${sourceDir}/builds/cmake/LinuxToolchain.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/linux-static"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/linux-static"
 			}
 		},
 		{
@@ -53,7 +53,7 @@
 			"name": "macos",
 			"displayName": "macOS",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/osx",
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/osx",
 				"CMAKE_OSX_DEPLOYMENT_TARGET": "10.9"
 			},
 			"condition": {
@@ -68,7 +68,7 @@
 			"toolchainFile": "$env{EASYRPG_BUILDSCRIPTS}/emscripten/emsdk-portable/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
 			"cacheVariables": {
 				"LIBLCF_ENABLE_TOOLS": "OFF",
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
 				"CMAKE_FIND_ROOT_PATH": "$env{EASYRPG_BUILDSCRIPTS}/emscripten"
 			}
 		},
@@ -77,7 +77,7 @@
 			"displayName": "Nintendo 3DS",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/3DS.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/3ds"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/3ds"
 			},
 			"inherits": "dkp-user"
 		},
@@ -86,7 +86,7 @@
 			"displayName": "Nintendo Switch",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Switch.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/switch"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/switch"
 			},
 			"inherits": "dkp-user"
 		},
@@ -95,7 +95,7 @@
 			"displayName": "Nintendo Wii",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Wii.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/wii"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wii"
 			},
 			"inherits": "dkp-user"
 		},

--- a/builds/cmake/CMakePresets.json.template
+++ b/builds/cmake/CMakePresets.json.template
@@ -77,7 +77,8 @@
 			"displayName": "Nintendo 3DS",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/3DS.cmake",
 			"cacheVariables": {
-				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/3ds"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/3ds",
+				"LIBLCF_ENABLE_TOOLS": "OFF"
 			},
 			"inherits": "dkp-user"
 		},
@@ -86,7 +87,8 @@
 			"displayName": "Nintendo Switch",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Switch.cmake",
 			"cacheVariables": {
-				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/switch"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/switch",
+				"LIBLCF_ENABLE_TOOLS": "OFF"
 			},
 			"inherits": "dkp-user"
 		},
@@ -95,7 +97,18 @@
 			"displayName": "Nintendo Wii",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Wii.cmake",
 			"cacheVariables": {
-				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wii"
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wii",
+				"LIBLCF_ENABLE_TOOLS": "OFF"
+			},
+			"inherits": "dkp-user"
+		},
+		{
+			"name": "wiiu",
+			"displayName": "Nintendo WiiU",
+			"toolchainFile": "$env{DEVKITPRO}/cmake/WiiU.cmake",
+			"cacheVariables": {
+				"LIBLCF_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wiiu",
+				"LIBLCF_ENABLE_TOOLS": "OFF"
 			},
 			"inherits": "dkp-user"
 		},

--- a/builds/cmake/CMakePresets.json.template
+++ b/builds/cmake/CMakePresets.json.template
@@ -22,10 +22,10 @@
 			}
 		},
 		{
-			"name": "windows-x86",
-			"displayName": "Windows (x86)",
+			"name": "windows",
+			"displayName": "Windows",
 			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x86-windows-static"
+				"VCPKG_TARGET_TRIPLET": "$env{VSCMD_ARG_TGT_ARCH}-windows-static"
 			},
 			"inherits": "win-user"
 		},
@@ -36,15 +36,6 @@
 			"architecture": "Win32",
 			"cacheVariables": {
 				"VCPKG_TARGET_TRIPLET": "x86-windows-static"
-			},
-			"inherits": "win-user"
-		},
-		{
-			"name": "windows-x64",
-			"displayName": "Windows (x64)",
-			"architecture": "x64",
-			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x64-windows-static"
 			},
 			"inherits": "win-user"
 		},

--- a/builds/cmake/CMakePresetsBase.json
+++ b/builds/cmake/CMakePresetsBase.json
@@ -17,7 +17,8 @@
 			"displayName": "build Debug",
 			"hidden": true,
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "Debug"
+				"CMAKE_BUILD_TYPE": "Debug",
+				"CMAKE_CONFIGURATION_TYPES": "Debug"
 			}
 		},
 		{
@@ -25,7 +26,8 @@
 			"displayName": "build RelWithDebInfo",
 			"hidden": true,
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "ReleaseWithDebInfo"
+				"CMAKE_BUILD_TYPE": "RelWithDebInfo",
+				"CMAKE_CONFIGURATION_TYPES": "RelWithDebInfo"
 			}
 		},
 		{
@@ -33,7 +35,8 @@
 			"displayName": "build release",
 			"hidden": true,
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "Release"
+				"CMAKE_BUILD_TYPE": "Release",
+				"CMAKE_CONFIGURATION_TYPES": "Release"
 			}
 		},
 		{

--- a/builds/cmake/liblcf-config.cmake.in
+++ b/builds/cmake/liblcf-config.cmake.in
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 find_dependency(inih REQUIRED)
 
-if(@LCF_SUPPORT_ICU@)
+if(@LCF_SUPPORT_ICU@ EQUAL 1)
 	find_dependency(ICU COMPONENTS i18n uc data REQUIRED)
 endif()
 

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -14,9 +14,14 @@
 #include <cstdio>
 #include <cstdlib>
 
-#if LCF_SUPPORT_ICU
+#if LCF_SUPPORT_ICU == 1
 #   include <unicode/ucsdet.h>
 #   include <unicode/ucnv.h>
+#elif LCF_SUPPORT_ICU == 2
+#	ifndef _WIN32
+#		error "icu.h only supported on Windows"
+#	endif
+#	include <icu.h>
 #else
 #   include <cstdint>
 #endif


### PR DESCRIPTION
Ported the normalization code to the ICU C-API so looks more ugly now :sweat_smile: but C++ has no stable ABI so Microsoft decided to only provide the C part.

This _does not_ remove 3rd party ICU support. When a custom ICU library is found it has preference.

Rest is just updating of presets based on Player preset updates.

---

For now I plan to keep using the vcpkg ICU library but when I do not want to maintain this anymore I can now simply drop it.
