### PR TITLE
Don't strictly require inih

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(MiscUtils)
 
 # Compilation options
 option(BUILD_SHARED_LIBS "Build shared library, disable for building the static library (default: ON)" ON)
-option(LIBLCF_WITH_INIH "INI parsing support (inih, required when building EasyRPG Player, default: ON)" ON)
+option(LIBLCF_WITH_INI "INI parsing support (inih, required when building EasyRPG Player, default: ON)" ON)
 option(LIBLCF_WITH_ICU "ICU encoding handling (when disabled only windows-1252 is supported, default: ON)" ON)
 option(LIBLCF_WITH_XML "XML reading support (expat, default: ON)" ON)
 option(LIBLCF_UPDATE_MIMEDB "Whether to run update-mime-database after install (default: ON)" ON)
@@ -293,15 +293,15 @@ set(LCF_HEADERS
 	src/lcf/third_party/string_view.h
 )
 
-set(LCF_SUPPORT_INIH 0)
-if(LIBLCF_WITH_INIH)
+set(LCF_SUPPORT_INI 0)
+if(LIBLCF_WITH_INI)
 	list(APPEND LCF_SOURCES
 		src/inireader.cpp
 	)
 	list(APPEND LCF_HEADERS
 		src/lcf/inireader.h
 	)
-	set(LCF_SUPPORT_INIH 1)
+	set(LCF_SUPPORT_INI 1)
 endif()
 
 add_library(lcf ${LCF_SOURCES} ${LCF_HEADERS})
@@ -354,7 +354,7 @@ set_property(TARGET lcf PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set_property(TARGET lcf PROPERTY EXPORT_NAME liblcf)
 
 # inih
-if (LCF_SUPPORT_INIH)
+if (LCF_SUPPORT_INI)
 	find_package(inih REQUIRED)
 	target_link_libraries(lcf inih::inih)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(MiscUtils)
 
 # Compilation options
 option(BUILD_SHARED_LIBS "Build shared library, disable for building the static library (default: ON)" ON)
-option(LIBLCF_WITH_INIH "INI parsing support, (inih, default: ON)" ON)
+option(LIBLCF_WITH_INIH "INI parsing support (inih, required when building EasyRPG Player, default: ON)" ON)
 option(LIBLCF_WITH_ICU "ICU encoding handling (when disabled only windows-1252 is supported, default: ON)" ON)
 option(LIBLCF_WITH_XML "XML reading support (expat, default: ON)" ON)
 option(LIBLCF_UPDATE_MIMEDB "Whether to run update-mime-database after install (default: ON)" ON)
@@ -293,8 +293,6 @@ set(LCF_HEADERS
 	src/lcf/third_party/string_view.h
 )
 
-
-
 set(LCF_SUPPORT_INIH 0)
 if(LIBLCF_WITH_INIH)
 	list(APPEND LCF_SOURCES
@@ -359,6 +357,8 @@ set_property(TARGET lcf PROPERTY EXPORT_NAME liblcf)
 if (LCF_SUPPORT_INIH)
 	find_package(inih REQUIRED)
 	target_link_libraries(lcf inih::inih)
+else()
+	message(STATUS "inih is disabled. This component is required when building EasyRPG Player.")
 endif ()
 
 # icu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include(MiscUtils)
 
 # Compilation options
 option(BUILD_SHARED_LIBS "Build shared library, disable for building the static library (default: ON)" ON)
+option(LIBLCF_WITH_INIH "INI parsing support, (inih, default: ON)" ON)
 option(LIBLCF_WITH_ICU "ICU encoding handling (when disabled only windows-1252 is supported, default: ON)" ON)
 option(LIBLCF_WITH_XML "XML reading support (expat, default: ON)" ON)
 option(LIBLCF_UPDATE_MIMEDB "Whether to run update-mime-database after install (default: ON)" ON)
@@ -30,7 +31,6 @@ set(LCF_SOURCES
 	src/dbarray.cpp
 	src/dbstring_struct.cpp
 	src/encoder.cpp
-	src/inireader.cpp
 	src/ldb_equipment.cpp
 	src/ldb_eventcommand.cpp
 	src/ldb_parameters.cpp
@@ -202,7 +202,6 @@ set(LCF_HEADERS
 	src/lcf/encoder.h
 	src/lcf/enum_tags.h
 	src/lcf/flag_set.h
-	src/lcf/inireader.h
 	src/lcf/ldb/reader.h
 	src/lcf/lmt/reader.h
 	src/lcf/lmu/reader.h
@@ -294,6 +293,19 @@ set(LCF_HEADERS
 	src/lcf/third_party/string_view.h
 )
 
+
+
+set(LCF_SUPPORT_INIH 0)
+if(LIBLCF_WITH_INIH)
+	list(APPEND LCF_SOURCES
+		src/inireader.cpp
+	)
+	list(APPEND LCF_HEADERS
+		src/lcf/inireader.h
+	)
+	set(LCF_SUPPORT_INIH 1)
+endif()
+
 add_library(lcf ${LCF_SOURCES} ${LCF_HEADERS})
 
 # IDE source grouping
@@ -344,8 +356,10 @@ set_property(TARGET lcf PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set_property(TARGET lcf PROPERTY EXPORT_NAME liblcf)
 
 # inih
-find_package(inih REQUIRED)
-target_link_libraries(lcf inih::inih)
+if (LCF_SUPPORT_INIH)
+	find_package(inih REQUIRED)
+	target_link_libraries(lcf inih::inih)
+endif ()
 
 # icu
 set(LCF_SUPPORT_ICU 0)

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,7 +48,6 @@ liblcf_la_SOURCES = \
 	src/dbarray.cpp \
 	src/dbstring_struct.cpp \
 	src/encoder.cpp \
-	src/inireader.cpp \
 	src/ldb_equipment.cpp \
 	src/ldb_eventcommand.cpp \
 	src/ldb_parameters.cpp \
@@ -219,7 +218,6 @@ lcfinclude_HEADERS = \
 	src/lcf/encoder.h \
 	src/lcf/enum_tags.h \
 	src/lcf/flag_set.h \
-	src/lcf/inireader.h \
 	src/lcf/log_handler.h \
 	src/lcf/reader_lcf.h \
 	src/lcf/reader_util.h \
@@ -230,6 +228,11 @@ lcfinclude_HEADERS = \
 	src/lcf/string_view.h \
 	src/lcf/writer_lcf.h \
 	src/lcf/writer_xml.h
+
+if SUPPORT_INI
+liblcf_la_SOURCES += src/inireader.cpp
+lcfinclude_HEADERS += src/lcf/inireader.h
+endif
 
 lcfldbinclude_HEADERS = \
 	src/lcf/ldb/reader.h \

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Documentation is available at the documentation wiki: https://wiki.easyrpg.org
 
 ## Requirements
 
-- [inih] for INI file reading. (required)
+- [inih] for INI file reading. (required when building EasyRPG Player)
 - [Expat] for XML reading support.
-- [ICU] for character encoding detection and conversion (recommended).
+- [ICU] for character encoding detection and conversion (recommended). When disabled only Windows-1252 is supported.
 
 
 ## Source code

--- a/builds/cmake/liblcf-config.cmake.in
+++ b/builds/cmake/liblcf-config.cmake.in
@@ -5,7 +5,7 @@ include(CMakeFindDependencyMacro)
 # Required to find our installed Findinih.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
-if(@LCF_SUPPORT_INIH@)
+if(@LCF_SUPPORT_INI@)
 	find_dependency(inih REQUIRED)
 endif()
 

--- a/builds/cmake/liblcf-config.cmake.in
+++ b/builds/cmake/liblcf-config.cmake.in
@@ -5,7 +5,9 @@ include(CMakeFindDependencyMacro)
 # Required to find our installed Findinih.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
-find_dependency(inih REQUIRED)
+if(@LCF_SUPPORT_INIH@)
+	find_dependency(inih REQUIRED)
+endif()
 
 if(@LCF_SUPPORT_ICU@ EQUAL 1)
 	find_dependency(ICU COMPONENTS i18n uc data REQUIRED)

--- a/builds/config.h.in
+++ b/builds/config.h.in
@@ -5,3 +5,6 @@
 
 /* Enable XML reading support (expat) */
 #define LCF_SUPPORT_XML @LCF_SUPPORT_XML@
+
+/* Enable INI reading support (INIH ) */
+#define LCF_SUPPORT_INIH @LCF_SUPPORT_INIH@

--- a/builds/config.h.in
+++ b/builds/config.h.in
@@ -7,4 +7,4 @@
 #define LCF_SUPPORT_XML @LCF_SUPPORT_XML@
 
 /* Enable INI reading support (INIH ) */
-#define LCF_SUPPORT_INIH @LCF_SUPPORT_INIH@
+#define LCF_SUPPORT_INI @LCF_SUPPORT_INI@

--- a/builds/config.h.in
+++ b/builds/config.h.in
@@ -6,5 +6,5 @@
 /* Enable XML reading support (expat) */
 #define LCF_SUPPORT_XML @LCF_SUPPORT_XML@
 
-/* Enable INI reading support (INIH ) */
+/* Enable INI reading support (INIH) */
 #define LCF_SUPPORT_INI @LCF_SUPPORT_INI@

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,13 @@ AS_IF([test "x$enable_xml" != "xno"],[
 ])
 AM_CONDITIONAL(SUPPORT_XML,[test $LCF_SUPPORT_XML == 1])
 
+AC_SUBST([LCF_SUPPORT_INI],[0])
+AC_ARG_ENABLE([ini],[AS_HELP_STRING([--disable-ini],[Disable INI reading support (inih) [default=no]])])
+AS_IF([test "x$enable_ini" != "xno"],[
+	AX_PKG_CHECK_MODULES([EXPAT],[],[ini >= 2.1],[LCF_SUPPORT_INI=1])
+])
+AM_CONDITIONAL(SUPPORT_INI,[test $LCF_SUPPORT_INI == 1])
+
 # Tools
 AC_ARG_ENABLE([tools],[AS_HELP_STRING([--disable-tools],[Do not build and install the tools [default=no]])])
 AM_CONDITIONAL(ENABLE_TOOLS,[test "x$enable_tools" != "xno"])

--- a/configure.ac
+++ b/configure.ac
@@ -21,8 +21,6 @@ LT_INIT([win32-dll])
 AM_CONDITIONAL(CROSS_COMPILING,[test "x$cross_compiling" = "xyes"])
 
 # Checks for libraries.
-AX_PKG_CHECK_MODULES([INIH],[],[inih],[])
-
 AC_SUBST([LCF_SUPPORT_ICU],[0])
 AC_ARG_ENABLE([icu],[AS_HELP_STRING([--disable-icu],[Disable ICU encoding handling (only windows-1252 supported) [default=no]])])
 AS_IF([test "x$enable_icu" != "xno"],[
@@ -39,7 +37,7 @@ AM_CONDITIONAL(SUPPORT_XML,[test $LCF_SUPPORT_XML == 1])
 AC_SUBST([LCF_SUPPORT_INI],[0])
 AC_ARG_ENABLE([ini],[AS_HELP_STRING([--disable-ini],[Disable INI reading support (inih) [default=no]])])
 AS_IF([test "x$enable_ini" != "xno"],[
-	AX_PKG_CHECK_MODULES([EXPAT],[],[ini >= 2.1],[LCF_SUPPORT_INI=1])
+	AX_PKG_CHECK_MODULES([INIH],[],[inih],[LCF_SUPPORT_INI=1])
 ])
 AM_CONDITIONAL(SUPPORT_INI,[test $LCF_SUPPORT_INI == 1])
 

--- a/src/lcf/reader_util.h
+++ b/src/lcf/reader_util.h
@@ -68,7 +68,7 @@ namespace ReaderUtil {
 	 * @return list of encodings or empty if not detected
 	 */
 	std::vector<std::string> DetectEncodings(StringView string);
-#if LCF_SUPPORT_INI
+
 	/**
 	 * Returns the encoding set in the ini file.
 	 *
@@ -86,7 +86,7 @@ namespace ReaderUtil {
 	 * @return encoding or empty string if not found.
 	 */
 	std::string GetEncoding(std::istream& filestream);
-#endif
+
 	/**
 	 * Returns the system encoding based on current locale settings.
 	 *

--- a/src/lcf/reader_util.h
+++ b/src/lcf/reader_util.h
@@ -68,7 +68,7 @@ namespace ReaderUtil {
 	 * @return list of encodings or empty if not detected
 	 */
 	std::vector<std::string> DetectEncodings(StringView string);
-#if LCF_SUPPORT_INIH
+#if LCF_SUPPORT_INI
 	/**
 	 * Returns the encoding set in the ini file.
 	 *

--- a/src/lcf/reader_util.h
+++ b/src/lcf/reader_util.h
@@ -68,7 +68,7 @@ namespace ReaderUtil {
 	 * @return list of encodings or empty if not detected
 	 */
 	std::vector<std::string> DetectEncodings(StringView string);
-
+#if LCF_SUPPORT_INIH
 	/**
 	 * Returns the encoding set in the ini file.
 	 *
@@ -86,7 +86,7 @@ namespace ReaderUtil {
 	 * @return encoding or empty string if not found.
 	 */
 	std::string GetEncoding(std::istream& filestream);
-
+#endif
 	/**
 	 * Returns the system encoding based on current locale settings.
 	 *

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -206,7 +206,7 @@ std::vector<std::string> ReaderUtil::DetectEncodings(StringView string) {
 	return encodings;
 }
 
-#if LCF_SUPPORT_INIH
+#if LCF_SUPPORT_INI
 std::string ReaderUtil::GetEncoding(StringView ini_file) {
 	INIReader ini(ToString(ini_file));
 	if (ini.ParseError() != -1) {

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -215,6 +215,8 @@ std::string ReaderUtil::GetEncoding(StringView ini_file) {
 			return ReaderUtil::CodepageToEncoding(atoi(encoding.c_str()));
 		}
 	}
+#else
+	Log::Warning("Could not get encoding from ini file, disabled in this liblcf build.");
 #endif
 	return {};
 }
@@ -228,6 +230,8 @@ std::string ReaderUtil::GetEncoding(std::istream& filestream) {
 			return ReaderUtil::CodepageToEncoding(atoi(encoding.c_str()));
 		}
 	}
+#else
+	Log::Warning("Could not get encoding from ini file, disabled in this liblcf build.");
 #endif
 	return {};
 }

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -206,8 +206,8 @@ std::vector<std::string> ReaderUtil::DetectEncodings(StringView string) {
 	return encodings;
 }
 
-#if LCF_SUPPORT_INI
 std::string ReaderUtil::GetEncoding(StringView ini_file) {
+#if LCF_SUPPORT_INI
 	INIReader ini(ToString(ini_file));
 	if (ini.ParseError() != -1) {
 		std::string encoding = ini.Get("EasyRPG", "Encoding", std::string());
@@ -215,10 +215,12 @@ std::string ReaderUtil::GetEncoding(StringView ini_file) {
 			return ReaderUtil::CodepageToEncoding(atoi(encoding.c_str()));
 		}
 	}
+#endif
 	return {};
 }
 
 std::string ReaderUtil::GetEncoding(std::istream& filestream) {
+#if LCF_SUPPORT_INI
 	INIReader ini(filestream);
 	if (ini.ParseError() != -1) {
 		std::string encoding = ini.Get("EasyRPG", "Encoding", std::string());
@@ -226,9 +228,9 @@ std::string ReaderUtil::GetEncoding(std::istream& filestream) {
 			return ReaderUtil::CodepageToEncoding(atoi(encoding.c_str()));
 		}
 	}
+#endif
 	return {};
 }
-#endif
 
 std::string ReaderUtil::GetLocaleEncoding() {
 #ifdef _WIN32

--- a/src/reader_util.cpp
+++ b/src/reader_util.cpp
@@ -206,6 +206,7 @@ std::vector<std::string> ReaderUtil::DetectEncodings(StringView string) {
 	return encodings;
 }
 
+#if LCF_SUPPORT_INIH
 std::string ReaderUtil::GetEncoding(StringView ini_file) {
 	INIReader ini(ToString(ini_file));
 	if (ini.ParseError() != -1) {
@@ -227,6 +228,7 @@ std::string ReaderUtil::GetEncoding(std::istream& filestream) {
 	}
 	return {};
 }
+#endif
 
 std::string ReaderUtil::GetLocaleEncoding() {
 #ifdef _WIN32

--- a/tools/lcf2xml.cpp
+++ b/tools/lcf2xml.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv)
 		std::cerr << "Usage: " << argv[0] << "[--2k] [--2k3] file1 [... fileN]" << std::endl;
 		std::cerr << "\t--2k: Treat files as RPG 2000" << std::endl;
 		std::cerr << "\t--2k3: Treat files as RPG 2003 (default)" << std::endl;
-		std::cerr << "\t--encoding N: Use encoding N as the file encoding" << std::endl; 
+		std::cerr << "\t--encoding N: Use encoding N as the file encoding" << std::endl;
 
 		return 1;
 	}
@@ -250,6 +250,7 @@ void PrintReaderError(const std::string data)
 int ReaderWriteToFile(const std::string& in, const std::string& out, FileTypes in_type, lcf::EngineVersion engine, std::string encoding)
 {
 	std::string path = GetPath(in) + "/";
+
 	if (encoding.empty()) {
 #ifdef _WIN32
 		encoding = lcf::ReaderUtil::GetEncoding(path + "RPG_RT.ini");
@@ -275,7 +276,7 @@ int ReaderWriteToFile(const std::string& in, const std::string& out, FileTypes i
 		}
 #endif
 	}
-	
+
 	if (encoding.empty()) {
 		encoding = lcf::ReaderUtil::GetLocaleEncoding();
 	}

--- a/tools/lcf2xml.cpp
+++ b/tools/lcf2xml.cpp
@@ -250,7 +250,7 @@ void PrintReaderError(const std::string data)
 int ReaderWriteToFile(const std::string& in, const std::string& out, FileTypes in_type, lcf::EngineVersion engine, std::string encoding)
 {
 	std::string path = GetPath(in) + "/";
-#if LCF_SUPPORT_INIH
+#if LCF_SUPPORT_INI
 	if (encoding.empty()) {
 #ifdef _WIN32
 		encoding = lcf::ReaderUtil::GetEncoding(path + "RPG_RT.ini");

--- a/tools/lcf2xml.cpp
+++ b/tools/lcf2xml.cpp
@@ -250,7 +250,7 @@ void PrintReaderError(const std::string data)
 int ReaderWriteToFile(const std::string& in, const std::string& out, FileTypes in_type, lcf::EngineVersion engine, std::string encoding)
 {
 	std::string path = GetPath(in) + "/";
-
+#if LCF_SUPPORT_INIH
 	if (encoding.empty()) {
 #ifdef _WIN32
 		encoding = lcf::ReaderUtil::GetEncoding(path + "RPG_RT.ini");
@@ -276,7 +276,8 @@ int ReaderWriteToFile(const std::string& in, const std::string& out, FileTypes i
 		}
 #endif
 	}
-
+#endif
+	
 	if (encoding.empty()) {
 		encoding = lcf::ReaderUtil::GetLocaleEncoding();
 	}

--- a/tools/lcf2xml.cpp
+++ b/tools/lcf2xml.cpp
@@ -250,7 +250,6 @@ void PrintReaderError(const std::string data)
 int ReaderWriteToFile(const std::string& in, const std::string& out, FileTypes in_type, lcf::EngineVersion engine, std::string encoding)
 {
 	std::string path = GetPath(in) + "/";
-#if LCF_SUPPORT_INI
 	if (encoding.empty()) {
 #ifdef _WIN32
 		encoding = lcf::ReaderUtil::GetEncoding(path + "RPG_RT.ini");
@@ -276,7 +275,6 @@ int ReaderWriteToFile(const std::string& in, const std::string& out, FileTypes i
 		}
 #endif
 	}
-#endif
 	
 	if (encoding.empty()) {
 		encoding = lcf::ReaderUtil::GetLocaleEncoding();


### PR DESCRIPTION
inih isn't used by anything in liblcf directly, relaxing this requirement and allowing it to be disabled enables outside projects to more easily integrate this library into their application.

This PR enables this while still making inih a default requirement, so the current behavior is the default one requiring no changes in existing apps (easyrpg-player)